### PR TITLE
V0.4 different list orders

### DIFF
--- a/src/main/java/seedu/multitasky/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/ListCommand.java
@@ -1,5 +1,11 @@
 package seedu.multitasky.logic.commands;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import seedu.multitasky.logic.parser.CliSyntax;
+
+// @@author A0125586X
 /**
  * Lists all entries in the entry book to the user.
  */
@@ -7,12 +13,71 @@ public class ListCommand extends Command {
 
     public static final String COMMAND_WORD = "list";
 
-    public static final String MESSAGE_SUCCESS = "Listed all entries";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists entries in the entry book. " + "\n"
+                                               + "Format: " + COMMAND_WORD
+                                               + " [" + "[" + CliSyntax.PREFIX_ARCHIVE + "]" + " |"
+                                               + " [" + CliSyntax.PREFIX_BIN + "]" + "]"
+                                               + " [" + CliSyntax.PREFIX_UPCOMING + "]"
+                                               + " [" + CliSyntax.PREFIX_REVERSE + "]" + "\n"
+                                               + "Example: " + COMMAND_WORD + " " + CliSyntax.PREFIX_UPCOMING;
+
+    public static final String MESSAGE_ACTIVE_SUCCESS = "Listed all active entries";
+
+    public static final String MESAGE_UPCOMING_SUCCESS = "Listed all upcoming entries";
+
+    public static final String MESSAGE_REVERSE_SUCCESS = "Listed all entries in reverse";
+
+    public static final String[] PREFIX_LIST = {CliSyntax.PREFIX_ARCHIVE.toString(),
+                                                CliSyntax.PREFIX_BIN.toString(),
+                                                CliSyntax.PREFIX_UPCOMING.toString(),
+                                                CliSyntax.PREFIX_REVERSE.toString()};
+
+    public enum ShowType {
+        ACTIVE, ARCHIVE, BIN
+    }
+
+    public enum Ordering {
+        DEFAULT, UPCOMING, REVERSE
+    }
+
+    private ShowType showType;
+    private Ordering ordering;
+
+    public ListCommand() {
+        showType = ShowType.ACTIVE;
+        ordering = Ordering.DEFAULT;
+    }
+
+    public ListCommand(ShowType showType, Ordering ordering) {
+        this.showType = showType;
+        this.ordering = ordering;
+    }
+
+    public ListCommand(String... flags) {
+        ArrayList<String> flagList = new ArrayList<String>(Arrays.asList(flags));
+
+        if (flagList.contains(CliSyntax.PREFIX_ARCHIVE.toString())) {
+            showType = ShowType.ARCHIVE;
+        } else if (flagList.contains(CliSyntax.PREFIX_BIN.toString())) {
+            showType = ShowType.BIN;
+        } else {
+            showType = ShowType.ACTIVE;
+        }
+
+        if (flagList.contains(CliSyntax.PREFIX_UPCOMING.toString())) {
+            ordering = Ordering.UPCOMING;
+        } else if (flagList.contains(CliSyntax.PREFIX_REVERSE.toString())) {
+            ordering = Ordering.REVERSE;
+        } else {
+            ordering = Ordering.DEFAULT;
+        }
+
+    }
 
     @Override
     public CommandResult execute() {
         model.updateAllFilteredListToShowAll();
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_ACTIVE_SUCCESS);
     }
 
 }

--- a/src/main/java/seedu/multitasky/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/ListCommand.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import seedu.multitasky.logic.parser.CliSyntax;
+import seedu.multitasky.model.entry.util.Comparators;
 
 // @@author A0125586X
 /**
@@ -23,9 +24,15 @@ public class ListCommand extends Command {
 
     public static final String MESSAGE_ACTIVE_SUCCESS = "Listed all active entries";
 
-    public static final String MESAGE_UPCOMING_SUCCESS = "Listed all upcoming entries";
+    public static final String MESSAGE_ARCHIVE_SUCCESS = "Listed all entries in the archive";
 
-    public static final String MESSAGE_REVERSE_SUCCESS = "Listed all entries in reverse";
+    public static final String MESSAGE_BIN_SUCCESS = "Listed all entries in the bin";
+
+    public static final String MESSAGE_DEFAULT_ORDER = "in default order";
+
+    public static final String MESSAGE_REVERSE_ORDER = "in reverse order";
+
+    public static final String MESSAGE_UPCOMING_ORDER = "in upcoming order";
 
     public static final String[] PREFIX_LIST = {CliSyntax.PREFIX_ARCHIVE.toString(),
                                                 CliSyntax.PREFIX_BIN.toString(),
@@ -37,7 +44,7 @@ public class ListCommand extends Command {
     }
 
     public enum Ordering {
-        DEFAULT, UPCOMING, REVERSE
+        DEFAULT, REVERSE, UPCOMING
     }
 
     private ShowType showType;
@@ -64,10 +71,10 @@ public class ListCommand extends Command {
             showType = ShowType.ACTIVE;
         }
 
-        if (flagList.contains(CliSyntax.PREFIX_UPCOMING.toString())) {
-            ordering = Ordering.UPCOMING;
-        } else if (flagList.contains(CliSyntax.PREFIX_REVERSE.toString())) {
+        if (flagList.contains(CliSyntax.PREFIX_REVERSE.toString())) {
             ordering = Ordering.REVERSE;
+        } else if (flagList.contains(CliSyntax.PREFIX_UPCOMING.toString())) {
+            ordering = Ordering.UPCOMING;
         } else {
             ordering = Ordering.DEFAULT;
         }
@@ -76,8 +83,43 @@ public class ListCommand extends Command {
 
     @Override
     public CommandResult execute() {
-        model.updateAllFilteredListToShowAll();
-        return new CommandResult(MESSAGE_ACTIVE_SUCCESS);
+        StringBuilder commandResultBuilder = new StringBuilder();
+        // TODO show archive/bin
+        switch (showType) {
+        case ARCHIVE:
+            commandResultBuilder.append(MESSAGE_ARCHIVE_SUCCESS);
+            break;
+        case BIN:
+            commandResultBuilder.append(MESSAGE_BIN_SUCCESS);
+            break;
+        case ACTIVE:
+            commandResultBuilder.append(MESSAGE_ACTIVE_SUCCESS);
+            break;
+        default:
+            throw new AssertionError("Unknown list show type");
+        }
+
+        switch (ordering) {
+        case REVERSE:
+            model.updateSortingComparators(Comparators.EVENT_REVERSE, Comparators.DEADLINE_REVERSE,
+                                           Comparators.FLOATING_TASK_REVERSE);
+            model.updateAllFilteredListToShowAll();
+            commandResultBuilder.append(" ").append(MESSAGE_REVERSE_ORDER);
+            return new CommandResult(commandResultBuilder.toString());
+        case UPCOMING:
+            model.updateSortingComparators(Comparators.EVENT_UPCOMING, Comparators.DEADLINE_UPCOMING,
+                                           Comparators.FLOATING_TASK_UPCOMING);
+            model.updateAllFilteredListToShowAll();
+            commandResultBuilder.append(" ").append(MESSAGE_UPCOMING_ORDER);
+            return new CommandResult(commandResultBuilder.toString());
+        case DEFAULT:
+            model.updateSortingComparators(Comparators.EVENT_DEFAULT, Comparators.DEADLINE_DEFAULT,
+                                           Comparators.FLOATING_TASK_DEFAULT);
+            model.updateAllFilteredListToShowAll();
+            return new CommandResult(commandResultBuilder.toString());
+        default:
+            throw new AssertionError("Unknown list command ordering type");
+        }
     }
 
 }

--- a/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
@@ -25,4 +25,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_ARCHIVE = new Prefix("/archive");
     public static final Prefix PREFIX_BIN = new Prefix("/bin");
 
+    /* List types */
+    public static final Prefix PREFIX_UPCOMING = new Prefix("/upcoming");
+    public static final Prefix PREFIX_REVERSE = new Prefix("/reverse");
+
 }

--- a/src/main/java/seedu/multitasky/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ListCommandParser.java
@@ -1,0 +1,51 @@
+package seedu.multitasky.logic.parser;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import seedu.multitasky.commons.core.Messages;
+import seedu.multitasky.logic.commands.ListCommand;
+import seedu.multitasky.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListCommandParser {
+
+    /** Parses the given arguments in the context of a list command.
+     *
+     * @param args the arguments for the list command in a single String
+     * @return     the ListCommand object for execution
+     * @throws ParseException if the user input does not confirm to the expected format
+     */
+    public ListCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            return new ListCommand();
+        }
+
+        // Flags are delimited by whitespace
+        final String[] flags = trimmedArgs.split("\\s+");
+        if (!hasValidFlagCombination(flags)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                                                   ListCommand.MESSAGE_USAGE));
+        }
+
+        return new ListCommand(flags);
+    }
+
+    private boolean hasValidFlagCombination(String... flags) {
+        ArrayList<String> flagList = new ArrayList<String>(Arrays.asList(flags));
+        // Cannot have any unknown flags
+        if (!Arrays.asList(ListCommand.PREFIX_LIST).containsAll(flagList)) {
+            return false;
+        }
+        // Check for invalid flag combinations
+        if (flagList.contains(CliSyntax.PREFIX_ARCHIVE.toString())
+            && flagList.contains(CliSyntax.PREFIX_BIN.toString())) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/seedu/multitasky/logic/parser/Parser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/Parser.java
@@ -63,7 +63,7 @@ public class Parser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListCommand();
+            return new ListCommandParser().parse(arguments);
 
         case UndoCommand.COMMAND_WORD:
             return new UndoCommand();

--- a/src/main/java/seedu/multitasky/logic/parser/Prefix.java
+++ b/src/main/java/seedu/multitasky/logic/parser/Prefix.java
@@ -2,7 +2,7 @@ package seedu.multitasky.logic.parser;
 
 /**
  * A prefix that marks the beginning of an argument in an arguments string.
- * E.g. 't/' in 'add James t/ friend'.
+ * E.g. '/tag' in 'add task /tag sample'.
  */
 public class Prefix {
     private final String prefix;

--- a/src/main/java/seedu/multitasky/model/EntryBook.java
+++ b/src/main/java/seedu/multitasky/model/EntryBook.java
@@ -3,6 +3,7 @@ package seedu.multitasky.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -132,6 +133,16 @@ public class EntryBook implements ReadOnlyEntryBook {
             assert false : "EntryBooks should not have duplicate tags";
         }
         syncMasterTagListWith(_activeList);
+    }
+    // @@author
+
+    // @@author A0125586X
+    public void setComparators(Comparator<ReadOnlyEntry> eventComparator,
+                               Comparator<ReadOnlyEntry> deadlineComparator,
+                               Comparator<ReadOnlyEntry> floatingTaskComparator) {
+        _eventList.setComparator(eventComparator);
+        _deadlineList.setComparator(deadlineComparator);
+        _floatingTaskList.setComparator(floatingTaskComparator);
     }
     // @@author
 

--- a/src/main/java/seedu/multitasky/model/Model.java
+++ b/src/main/java/seedu/multitasky/model/Model.java
@@ -1,5 +1,6 @@
 package seedu.multitasky.model;
 
+import java.util.Comparator;
 import java.util.Set;
 
 import seedu.multitasky.commons.core.UnmodifiableObservableList;
@@ -77,5 +78,10 @@ public interface Model {
 
     /** Updates the filter of the filtered floating task list to filter by the given keywords */
     void updateFilteredFloatingTaskList(Set<String> keywords);
+
+    /** Updates the sorting comparators used. */
+    void updateSortingComparators(Comparator<ReadOnlyEntry> eventComparator,
+                                  Comparator<ReadOnlyEntry> deadlineComparator,
+                                  Comparator<ReadOnlyEntry> floatingTaskComparator);
 
 }

--- a/src/main/java/seedu/multitasky/model/ModelManager.java
+++ b/src/main/java/seedu/multitasky/model/ModelManager.java
@@ -2,6 +2,7 @@ package seedu.multitasky.model;
 
 import static seedu.multitasky.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Set;
 import java.util.logging.Logger;
 
@@ -236,6 +237,16 @@ public class ModelManager extends ComponentManager implements Model {
     private void updateFilteredFloatingTaskList(Expression expression) {
         _filteredFloatingTaskList.setPredicate(expression::satisfies);
     }
+    // @@author
+
+    // @@author A0125586X
+    /** Updates the sorting comparators used. */
+    public void updateSortingComparators(Comparator<ReadOnlyEntry> eventComparator,
+                                         Comparator<ReadOnlyEntry> deadlineComparator,
+                                         Comparator<ReadOnlyEntry> floatingTaskComparator) {
+        _entryBook.setComparators(eventComparator, deadlineComparator, floatingTaskComparator);
+    }
+    // @@author
 
     // @@author A0126623L
     @Override

--- a/src/main/java/seedu/multitasky/model/entry/Deadline.java
+++ b/src/main/java/seedu/multitasky/model/entry/Deadline.java
@@ -78,18 +78,6 @@ public class Deadline extends Entry {
                || this.isSameStateAs((ReadOnlyEntry) other);
     }
 
-    // @@author A0125586X
-    /**
-     * Compares this to another deadline for sorting by due(end) date.
-     *
-     * @return <0 if this deadline is sooner, 0 if they're the same, and >0 if this deadline is later
-     */
-    @Override
-    public int compareTo(ReadOnlyEntry other) throws NullPointerException, ClassCastException {
-        assert other instanceof Deadline : "Deadline::compareTo must receive Deadline object as argument";
-        return this.getEndDateAndTime().compareTo(other.getEndDateAndTime());
-    }
-
     // @@author A0126623L
     @Override
     public boolean isSameStateAs(ReadOnlyEntry other) {

--- a/src/main/java/seedu/multitasky/model/entry/DeadlineList.java
+++ b/src/main/java/seedu/multitasky/model/entry/DeadlineList.java
@@ -4,12 +4,20 @@ import java.util.List;
 
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
 import seedu.multitasky.model.entry.exceptions.EntryNotFoundException;
+import seedu.multitasky.model.entry.util.Comparators;
 
 //@@author A0126623L
 /**
  * A list of Deadline objects that does not allow nulls.
  */
 public class DeadlineList extends EntryList {
+
+    // @@author A0125586X
+    public DeadlineList() {
+        super();
+        comparator = Comparators.DEADLINE_DEFAULT;
+    }
+    // @@author
 
     // @@author A0126623L
     /**

--- a/src/main/java/seedu/multitasky/model/entry/EntryList.java
+++ b/src/main/java/seedu/multitasky/model/entry/EntryList.java
@@ -3,6 +3,7 @@ package seedu.multitasky.model.entry;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 
 import javafx.collections.FXCollections;
@@ -11,6 +12,7 @@ import seedu.multitasky.commons.core.UnmodifiableObservableList;
 import seedu.multitasky.commons.util.CollectionUtil;
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
 import seedu.multitasky.model.entry.exceptions.EntryNotFoundException;
+import seedu.multitasky.model.entry.util.Comparators;
 
 /**
  * A list of entries that does not allow nulls.
@@ -22,6 +24,8 @@ import seedu.multitasky.model.entry.exceptions.EntryNotFoundException;
 public abstract class EntryList implements Iterable<Entry> {
 
     protected final ObservableList<Entry> internalList = FXCollections.observableArrayList();
+
+    protected Comparator<ReadOnlyEntry> comparator = Comparators.ENTRY_DEFAULT;
 
     // @@author A0126623L
     /**
@@ -124,11 +128,18 @@ public abstract class EntryList implements Iterable<Entry> {
 
     // @@author A0125586X
     /**
-     * Sorts the internal list by the Comparable interface already implemented for the various
-     * Entry subclasses
+     * Sorts the internal list using the comparator stored inside the class
      */
     protected void sortInternalList() {
-        Collections.sort(internalList);
+        Collections.sort(internalList, comparator);
+    }
+
+    /**
+     * Sets the comparator for this list, and sorts it using the comparator.
+     */
+    public void setComparator(Comparator<ReadOnlyEntry> comparator) {
+        this.comparator = comparator;
+        sortInternalList();
     }
     // @@author
 }

--- a/src/main/java/seedu/multitasky/model/entry/Event.java
+++ b/src/main/java/seedu/multitasky/model/entry/Event.java
@@ -82,19 +82,6 @@ public class Event extends Entry {
                || this.isSameStateAs((ReadOnlyEntry) other);
     }
 
-    // @@author A0125586X
-    /**
-     * Compares this to another event for sorting by starting date.
-     *
-     * @return <0 if this event is sooner, 0 if they're the same, and >0 if this event is later
-     */
-    @Override
-    public int compareTo(ReadOnlyEntry other) throws NullPointerException, ClassCastException {
-        assert other instanceof Event : "Event::compareTo must receive Event object as argument";
-        return this.getStartDateAndTime().compareTo(other.getStartDateAndTime());
-    }
-    // @@author
-
     @Override
     public boolean isSameStateAs(ReadOnlyEntry other) {
         return (other instanceof Event && this.getName().equals(other.getName()) // instanceof handles nulls

--- a/src/main/java/seedu/multitasky/model/entry/EventList.java
+++ b/src/main/java/seedu/multitasky/model/entry/EventList.java
@@ -4,12 +4,20 @@ import java.util.List;
 
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
 import seedu.multitasky.model.entry.exceptions.EntryNotFoundException;
+import seedu.multitasky.model.entry.util.Comparators;
 
 //@@author A0126623L
 /**
  * A list of Event objects that does not allow nulls.
  */
 public class EventList extends EntryList {
+
+    // @@author A0125586X
+    public EventList() {
+        super();
+        comparator = Comparators.EVENT_DEFAULT;
+    }
+    // @@author
 
     // @@author A0126623L
     /**

--- a/src/main/java/seedu/multitasky/model/entry/FloatingTask.java
+++ b/src/main/java/seedu/multitasky/model/entry/FloatingTask.java
@@ -52,18 +52,6 @@ public class FloatingTask extends Entry {
                || this.isSameStateAs((ReadOnlyEntry) other);
     }
 
-    // @@author A0125586X
-    /**
-     * Compares this to another floating task.
-     *
-     * @return 0 as there is no ordering to floating tasks at the moment.
-     */
-    @Override
-    public int compareTo(ReadOnlyEntry other) throws NullPointerException, ClassCastException {
-        assert other instanceof FloatingTask : "FloatingTask::compareTo must receive FloatingTask object as argument";
-        return 0;
-    }
-
     // @@author A0126623L
     /**
      * Compares the state with another Floating Task.

--- a/src/main/java/seedu/multitasky/model/entry/FloatingTaskList.java
+++ b/src/main/java/seedu/multitasky/model/entry/FloatingTaskList.java
@@ -3,8 +3,16 @@ package seedu.multitasky.model.entry;
 import java.util.List;
 
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
+import seedu.multitasky.model.entry.util.Comparators;
 
 public class FloatingTaskList extends EntryList {
+
+    // @@author A0125586X
+    public FloatingTaskList() {
+        super();
+        comparator = Comparators.FLOATING_TASK_DEFAULT;
+    }
+    // @@author
 
     // @@author A0126623L
     /**

--- a/src/main/java/seedu/multitasky/model/entry/ReadOnlyEntry.java
+++ b/src/main/java/seedu/multitasky/model/entry/ReadOnlyEntry.java
@@ -9,7 +9,7 @@ import seedu.multitasky.model.tag.Tag;
  * A read-only immutable interface for a Entry in the entrybook.
  * Implementations should guarantee: details are present and not null, field values are validated.
  */
-public interface ReadOnlyEntry extends Comparable<ReadOnlyEntry> {
+public interface ReadOnlyEntry {
 
     Name getName();
 

--- a/src/main/java/seedu/multitasky/model/entry/util/Comparators.java
+++ b/src/main/java/seedu/multitasky/model/entry/util/Comparators.java
@@ -1,0 +1,185 @@
+package seedu.multitasky.model.entry.util;
+
+import java.util.Calendar;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import seedu.multitasky.model.entry.Deadline;
+import seedu.multitasky.model.entry.Event;
+import seedu.multitasky.model.entry.FloatingTask;
+import seedu.multitasky.model.entry.ReadOnlyEntry;
+
+// @@author A0125586X
+/**
+ * Utility class of different comparators to use when comparing two entries
+ */
+public class Comparators {
+
+    /**
+     * Default ordering in general is to have no change
+     */
+    public static final Comparator<ReadOnlyEntry> ENTRY_DEFAULT = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            return 0;
+        }
+    };
+
+    /**
+     * Default ordering for events is by starting date and time, earliest first
+     */
+    public static final Comparator<ReadOnlyEntry> EVENT_DEFAULT = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            assert entry2 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            // Order by increasing starting date and time
+            return entry1.getStartDateAndTime().compareTo(entry2.getStartDateAndTime());
+        }
+    };
+
+    /**
+     * Default ordering for deadlines is by ending date and time, earliest first
+     */
+    public static final Comparator<ReadOnlyEntry> DEADLINE_DEFAULT = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Deadline : "Deadline comparator must receive Deadline"
+                                                + "object as argument";
+            assert entry2 instanceof Deadline : "Event comparator must receive Deadline"
+                                                + "object as argument";
+            // Order by increasing ending(deadline) date and time
+            return entry1.getEndDateAndTime().compareTo(entry2.getEndDateAndTime());
+        }
+    };
+
+    /**
+     * Default ordering for floating tasks is the order in which they were added, earliest first
+     */
+    public static final Comparator<ReadOnlyEntry> FLOATING_TASK_DEFAULT = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof FloatingTask : "FloatingTask comparator must receive FloatingTask"
+                                                    + "object as argument";
+            assert entry2 instanceof FloatingTask : "FloatingTask comparator must receive FloatingTask"
+                                                    + "object as argument";
+            // No re-ordering of floating tasks
+            return 0;
+        }
+    };
+
+    /**
+     * Reverse ordering for events is by starting date and time, latest first
+     */
+    public static final Comparator<ReadOnlyEntry> EVENT_REVERSE = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            assert entry2 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            // Order by increasing starting date and time
+            return entry2.getStartDateAndTime().compareTo(entry1.getStartDateAndTime());
+        }
+    };
+
+    /**
+     * Default ordering for deadlines is by ending date and time, latest first
+     */
+    public static final Comparator<ReadOnlyEntry> DEADLINE_REVERSE = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Deadline : "Deadline comparator must receive Deadline"
+                                                + "object as argument";
+            assert entry2 instanceof Deadline : "Event comparator must receive Deadline"
+                                                + "object as argument";
+            // Order by increasing ending(deadline) date and time
+            return entry2.getEndDateAndTime().compareTo(entry1.getEndDateAndTime());
+        }
+    };
+
+    /**
+     * Default ordering for floating tasks is the order in which they were added, earliest first
+     */
+    public static final Comparator<ReadOnlyEntry> FLOATING_TASK_REVERSE = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof FloatingTask : "FloatingTask comparator must receive FloatingTask"
+                                                    + "object as argument";
+            assert entry2 instanceof FloatingTask : "FloatingTask comparator must receive FloatingTask"
+                                                    + "object as argument";
+            // No re-ordering of floating tasks
+            return 0;
+        }
+    };
+
+    /**
+     * Upcoming ordering for events is to show events that are not over yet first,
+     * followed by events that are over.
+     */
+    public static final Comparator<ReadOnlyEntry> EVENT_UPCOMING = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            assert entry2 instanceof Event : "Event comparator must receive Event"
+                                             + "object as argument";
+            Calendar currentTime = new GregorianCalendar();
+            currentTime.setTime(new Date());
+            if (entry1.getStartDateAndTime().before(currentTime)) {
+                if (entry2.getStartDateAndTime().before(currentTime)) {
+                    // Both events are in the past, perform normal sort relative to each other
+                    return entry1.getStartDateAndTime().compareTo(entry2.getStartDateAndTime());
+                } else {
+                    // wrong order: entry1 should be after entry2 since it is in the past and entry2 is not
+                    return 1;
+                }
+            } else if (entry2.getStartDateAndTime().before(currentTime)) {
+                // correct order: entry2 should be after entry1 since it is in the past and entry1 is not
+                return -1;
+            } else {
+                // Both events are upcoming, perform normal sort relative to each other
+                return entry1.getStartDateAndTime().compareTo(entry2.getStartDateAndTime());
+            }
+        }
+    };
+
+    /**
+     * Upcoming ordering for deadlines is to show deadlines that are not over yet first,
+     * followed by deadlines that are over.
+     */
+    public static final Comparator<ReadOnlyEntry> DEADLINE_UPCOMING = new Comparator<ReadOnlyEntry>() {
+        @Override
+        public int compare(ReadOnlyEntry entry1, ReadOnlyEntry entry2) {
+            assert entry1 instanceof Deadline : "Deadline comparator must receive Deadline"
+                                                + "object as argument";
+            assert entry2 instanceof Deadline : "Deadline comparator must receive Deadline"
+                                                + "object as argument";
+            Calendar currentTime = new GregorianCalendar();
+            currentTime.setTime(new Date());
+            if (entry1.getEndDateAndTime().before(currentTime)) {
+                if (entry2.getEndDateAndTime().before(currentTime)) {
+                    // Both deadlines are in the past, perform normal sort relative to each other
+                    return entry1.getEndDateAndTime().compareTo(entry2.getEndDateAndTime());
+                } else {
+                    // wrong order: entry1 should be after entry2 since it is in the past and entry2 is not
+                    return 1;
+                }
+            } else if (entry2.getEndDateAndTime().before(currentTime)) {
+                // correct order: entry2 should be after entry1 since it is in the past and entry1 is not
+                return -1;
+            } else {
+                // Both deadlines are upcoming, perform normal sort relative to each other
+                return entry1.getEndDateAndTime().compareTo(entry2.getEndDateAndTime());
+            }
+        }
+    };
+
+    /**
+     * Upcoming ordering for floating tasks is the order in which they were added
+     */
+    public static final Comparator<ReadOnlyEntry> FLOATING_TASK_UPCOMING = FLOATING_TASK_DEFAULT;
+}

--- a/src/test/java/seedu/multitasky/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/multitasky/logic/LogicManagerTest.java
@@ -238,7 +238,7 @@ public class LogicManagerTest {
         // prepare entry book state
         helper.addToModel(model, 2);
 
-        assertCommandSuccess(ListCommand.COMMAND_WORD, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(ListCommand.COMMAND_WORD, ListCommand.MESSAGE_ACTIVE_SUCCESS, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/multitasky/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/AddCommandTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
 
 import org.junit.Rule;
@@ -164,6 +165,13 @@ public class AddCommandTest {
 
         @Override
         public void redoPreviousAction() throws NothingToRedoException {
+            fail("This method should not be called.");
+        }
+
+        @Override
+        public void updateSortingComparators(Comparator<ReadOnlyEntry> eventComparator,
+                                             Comparator<ReadOnlyEntry> deadlineComparator,
+                                             Comparator<ReadOnlyEntry> floatingTaskComparator) {
             fail("This method should not be called.");
         }
 

--- a/src/test/java/seedu/multitasky/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/ListCommandTest.java
@@ -39,13 +39,13 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() throws Exception {
-        assertCommandSuccess(listCommand, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(listCommand, model, ListCommand.MESSAGE_ACTIVE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() throws Exception {
         showFirstEntryOnly(model);
-        assertCommandSuccess(listCommand, model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(listCommand, model, ListCommand.MESSAGE_ACTIVE_SUCCESS, expectedModel);
     }
 
     /**

--- a/src/test/java/seedu/multitasky/testutil/TestUtil.java
+++ b/src/test/java/seedu/multitasky/testutil/TestUtil.java
@@ -168,14 +168,16 @@ public class TestUtil {
     public static Entry[] addEntriesToSortedList(final Entry[] entries, Entry... entriesToAdd) {
         List<Entry> listOfEntries = asList(entries);
         listOfEntries.addAll(asList(entriesToAdd));
-        if (entries instanceof Event[]) {
-            Collections.sort(listOfEntries, Comparators.EVENT_DEFAULT);
-        } else if (entries instanceof Deadline[]) {
-            Collections.sort(listOfEntries, Comparators.DEADLINE_DEFAULT);
-        } else if (entries instanceof FloatingTask[]) {
-            Collections.sort(listOfEntries, Comparators.FLOATING_TASK_DEFAULT);
-        } else {
-            throw new AssertionError("Unknown entry array type");
+        if (entries.length > 0) {
+            if (entries[0] instanceof Event) {
+                Collections.sort(listOfEntries, Comparators.EVENT_DEFAULT);
+            } else if (entries[0] instanceof Deadline) {
+                Collections.sort(listOfEntries, Comparators.DEADLINE_DEFAULT);
+            } else if (entries[0] instanceof FloatingTask) {
+                Collections.sort(listOfEntries, Comparators.FLOATING_TASK_DEFAULT);
+            } else {
+                throw new AssertionError("Unknown entry array type");
+            }
         }
         return listOfEntries.toArray(new Entry[listOfEntries.size()]);
     }

--- a/src/test/java/seedu/multitasky/testutil/TestUtil.java
+++ b/src/test/java/seedu/multitasky/testutil/TestUtil.java
@@ -19,10 +19,13 @@ import seedu.multitasky.commons.core.index.Index;
 import seedu.multitasky.commons.exceptions.IllegalValueException;
 import seedu.multitasky.commons.util.FileUtil;
 import seedu.multitasky.commons.util.XmlUtil;
+import seedu.multitasky.model.entry.Deadline;
 import seedu.multitasky.model.entry.Entry;
+import seedu.multitasky.model.entry.Event;
 import seedu.multitasky.model.entry.FloatingTask;
 import seedu.multitasky.model.entry.Name;
 import seedu.multitasky.model.entry.ReadOnlyEntry;
+import seedu.multitasky.model.entry.util.Comparators;
 
 /**
  * A utility class for test cases.
@@ -165,7 +168,15 @@ public class TestUtil {
     public static Entry[] addEntriesToSortedList(final Entry[] entries, Entry... entriesToAdd) {
         List<Entry> listOfEntries = asList(entries);
         listOfEntries.addAll(asList(entriesToAdd));
-        Collections.sort(listOfEntries);
+        if (entries instanceof Event[]) {
+            Collections.sort(listOfEntries, Comparators.EVENT_DEFAULT);
+        } else if (entries instanceof Deadline[]) {
+            Collections.sort(listOfEntries, Comparators.DEADLINE_DEFAULT);
+        } else if (entries instanceof FloatingTask[]) {
+            Collections.sort(listOfEntries, Comparators.FLOATING_TASK_DEFAULT);
+        } else {
+            throw new AssertionError("Unknown entry array type");
+        }
         return listOfEntries.toArray(new Entry[listOfEntries.size()]);
     }
 


### PR DESCRIPTION
Comparable interface and compareTo(...) has been removed from the entries as they're now using external comparators that we can change as needed.

@ChuaPingChan please advise if how I implemented the API calls is consistent with what is already there, and whether model.entry.util.Comparators should be in a different folder.

@kevinLamKB please advise if my code for the ListCommand and ListCommandParser is consistent with the rest of `logic`