### PR TITLE
V0.4 smart input parsing

### DIFF
--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -27,10 +27,6 @@ import seedu.multitasky.model.tag.Tag;
 public class AddCommandParser {
     private ArgumentMultimap argMultimap;
 
-    public ArgumentMultimap getArgMultimap() {
-        return argMultimap;
-    }
-
     /**
      * Parses the given {@code String} of arguments in the context of the
      * AddCommand and returns an AddCommand object for execution.
@@ -39,6 +35,8 @@ public class AddCommandParser {
     public AddCommand parse(String args) throws ParseException {
         argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BY, PREFIX_AT, PREFIX_FROM,
                                                  PREFIX_TO, PREFIX_TAG);
+        argMultimap.bringUnusedPrefixArgsToPreamble(PREFIX_BY, PREFIX_AT, PREFIX_FROM,
+                                                    PREFIX_TO, PREFIX_TAG);
         Calendar startDate = null;
         Calendar endDate = null;
         Prefix datePrefix;

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -35,7 +35,6 @@ public class AddCommandParser {
     public AddCommand parse(String args) throws ParseException {
         argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BY, PREFIX_AT, PREFIX_FROM,
                                                  PREFIX_TO, PREFIX_TAG);
-
         Calendar startDate = null;
         Calendar endDate = null;
         Prefix datePrefix;

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -35,8 +35,7 @@ public class AddCommandParser {
     public AddCommand parse(String args) throws ParseException {
         argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_BY, PREFIX_AT, PREFIX_FROM,
                                                  PREFIX_TO, PREFIX_TAG);
-        argMultimap.bringUnusedPrefixArgsToPreamble(PREFIX_BY, PREFIX_AT, PREFIX_FROM,
-                                                    PREFIX_TO, PREFIX_TAG);
+
         Calendar startDate = null;
         Calendar endDate = null;
         Prefix datePrefix;

--- a/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
@@ -61,23 +61,4 @@ public class ArgumentMultimap {
         return getValue(new Prefix(""));
     }
 
-    /**
-     * Extends preamble value within the ArgumentMultimap with any prefixs and their values,
-     * if the prefix has more than one value mapped to it.
-     */
-    public void bringUnusedPrefixArgsToPreamble(Prefix...prefixs) {
-        Prefix preamblePrefix = new Prefix("");
-        for (Prefix prefix : prefixs) {
-            List<String> list = getAllValues(prefix);
-            if (list.size() > 1) { //more than one prefix used to describe
-                for (int i = 0; i < list.size() - 1; i++) { //all except last value
-                    String toConcat = argMultimap.get(preamblePrefix).get(0) + " " + prefix.toString() + " " + list.get(i);
-                    List<String> replacementList = new ArrayList<>();
-                    replacementList.add(toConcat);
-                    argMultimap.put(preamblePrefix, replacementList);
-                }
-            }
-        }
-    }
-
 }

--- a/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+
 /**
  * Stores mapping of prefixes to their respective arguments.
  * Each key may be associated with multiple argument values.
@@ -58,6 +59,25 @@ public class ArgumentMultimap {
      */
     public Optional<String> getPreamble() {
         return getValue(new Prefix(""));
+    }
+
+    /**
+     * Extends preamble value within the ArgumentMultimap with any prefixs and their values,
+     * if the prefix has more than one value mapped to it.
+     */
+    public void bringUnusedPrefixArgsToPreamble(Prefix...prefixs) {
+        Prefix preamblePrefix = new Prefix("");
+        for (Prefix prefix : prefixs) {
+            List<String> list = getAllValues(prefix);
+            if (list.size() > 1) { //more than one prefix used to describe
+                for (int i = 0; i < list.size() - 1; i++) { //all except last value
+                    String toConcat = argMultimap.get(preamblePrefix).get(0) + " " + prefix.toString() + " " + list.get(i);
+                    List<String> replacementList = new ArrayList<>();
+                    replacementList.add(toConcat);
+                    argMultimap.put(preamblePrefix, replacementList);
+                }
+            }
+        }
     }
 
 }

--- a/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
-
 /**
  * Stores mapping of prefixes to their respective arguments.
  * Each key may be associated with multiple argument values.

--- a/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
@@ -16,6 +16,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_AT = new Prefix("at");
     public static final Prefix PREFIX_TO = new Prefix("to");
     public static final Prefix PREFIX_TAG = new Prefix("tag");
+    public static final Prefix PREFIX_ESCAPE = new Prefix("\\");
 
     /* Entry type */
     public static final Prefix PREFIX_EVENT = new Prefix("event");

--- a/src/main/java/seedu/multitasky/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/DeleteCommandParser.java
@@ -59,9 +59,9 @@ public class DeleteCommandParser {
             }
 
         } else { // process to delete by find.
-            String trimmedArgs = argMultimap.getPreamble().get();
-
-            final String[] keywords = trimmedArgs.split("\\s+");
+            String searchString = argMultimap.getPreamble().get()
+                                             .replaceAll("\\" + CliSyntax.PREFIX_ESCAPE, "");
+            final String[] keywords = searchString.split("\\s+");
             final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
 
             return new DeleteByFindCommand(keywordSet);

--- a/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
@@ -76,7 +76,7 @@ public class EditCommandParser {
 
             initEntryEditor(argMultimap, editEntryDescriptor);
             String searchString = argMultimap.getPreamble().get()
-                    .replaceAll("\\" + CliSyntax.PREFIX_ESCAPE, "");
+                                             .replaceAll("\\" + CliSyntax.PREFIX_ESCAPE, "");
             final String[] keywords = searchString.split("\\s+");
             final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
 

--- a/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
@@ -21,7 +21,6 @@ import java.util.Set;
 
 import seedu.multitasky.commons.core.index.Index;
 import seedu.multitasky.commons.exceptions.IllegalValueException;
-import seedu.multitasky.logic.commands.DeleteCommand;
 import seedu.multitasky.logic.commands.EditByFindCommand;
 import seedu.multitasky.logic.commands.EditByIndexCommand;
 import seedu.multitasky.logic.commands.EditCommand;
@@ -47,7 +46,6 @@ public class EditCommandParser {
         argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FLOATINGTASK, PREFIX_DEADLINE, PREFIX_EVENT,
                                                  PREFIX_NAME, PREFIX_FROM, PREFIX_BY, PREFIX_AT, PREFIX_TO,
                                                  PREFIX_TAG);
-        String argPreamble = argMultimap.getPreamble().get();
         EditEntryDescriptor editEntryDescriptor = new EditEntryDescriptor();
 
         if (args.trim().isEmpty()) { // print help message if command word used without args
@@ -58,7 +56,7 @@ public class EditCommandParser {
         if (hasIndexFlag(argMultimap)) { // edit by index
             if (hasInvalidFlagCombination(argMultimap)) {
                 throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                                                       DeleteCommand.MESSAGE_USAGE));
+                                                       EditCommand.MESSAGE_USAGE));
             }
 
             Index index;
@@ -77,7 +75,9 @@ public class EditCommandParser {
         } else { // search by find
 
             initEntryEditor(argMultimap, editEntryDescriptor);
-            final String[] keywords = argPreamble.split("\\s+");
+            String searchString = argMultimap.getPreamble().get()
+                    .replaceAll("\\" + CliSyntax.PREFIX_ESCAPE, "");
+            final String[] keywords = searchString.split("\\s+");
             final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
 
             return new EditByFindCommand(keywordSet, editEntryDescriptor);

--- a/src/main/java/seedu/multitasky/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/FindCommandParser.java
@@ -28,8 +28,9 @@ public class FindCommandParser {
                                                    FindCommand.MESSAGE_USAGE));
         }
 
+        String searchString = trimmedArgs.replaceAll("\\" + CliSyntax.PREFIX_ESCAPE, "");
         // keywords delimited by whitespace
-        final String[] keywords = trimmedArgs.split("\\s+");
+        final String[] keywords = searchString.split("\\s+");
         final Set<String> keywordSet = new HashSet<>(Arrays.asList(keywords));
         return new FindCommand(keywordSet);
     }

--- a/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
@@ -55,7 +55,11 @@ public class ParserUtil {
      */
     public static Optional<Name> parseName(Optional<String> name) throws IllegalValueException {
         requireNonNull(name);
-        return name.isPresent() ? Optional.of(new Name(name.get())) : Optional.empty();
+        if (!name.isPresent()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(new Name(name.get().replaceAll("\\" + CliSyntax.PREFIX_ESCAPE.toString(), "")));
+        }
     }
 
     /**


### PR DESCRIPTION
- Implement escape character \ so that users can use `\by` to add `by` in adding or editing name to their entries.
- no escape letters for tags yet, i  don't see much point in it
- remove logic manager smart input parsing, too many overlapping possibilities to devise a good algorithm.

