### PR TITLE
V0.4 addcommand smart parsing

### DIFF
--- a/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
@@ -69,8 +69,6 @@ public class ArgumentMultimap {
         for (String prefix : prefixes) {
             if (getAllValues(new Prefix(prefix)).size() != 0) {
                 presentPrefixes.add(prefix);
-            } else {
-                // continue
             }
         }
         return presentPrefixes;

--- a/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ArgumentMultimap.java
@@ -60,4 +60,20 @@ public class ArgumentMultimap {
         return getValue(new Prefix(""));
     }
 
+    // @@author A0125586X
+    /**
+     * Method to extract an ArrayList of specified prefixes that are present in the ArgumentMultimap
+     */
+    public ArrayList<String> getPresentPrefixes(String... prefixes) {
+        ArrayList<String> presentPrefixes = new ArrayList<>();
+        for (String prefix : prefixes) {
+            if (getAllValues(new Prefix(prefix)).size() != 0) {
+                presentPrefixes.add(prefix);
+            } else {
+                // continue
+            }
+        }
+        return presentPrefixes;
+    }
+
 }

--- a/src/main/java/seedu/multitasky/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ListCommandParser.java
@@ -30,7 +30,7 @@ public class ListCommandParser {
         // TODO modify ArgumentTokenizer to be able to detect without preamble
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize("preamble " + trimmedArgs,
                                                                        toPrefixArray(ListCommand.VALID_PREFIXES));
-        ArrayList<String> prefixesPresent = getPresentPrefixes(argumentMultimap, ListCommand.VALID_PREFIXES);
+        ArrayList<String> prefixesPresent = argumentMultimap.getPresentPrefixes(ListCommand.VALID_PREFIXES);
         if (!hasValidPrefixCombination(prefixesPresent)) {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                                                    ListCommand.MESSAGE_USAGE));
@@ -61,17 +61,6 @@ public class ListCommandParser {
         } catch (ParseException e) {
             return null;
         }
-    }
-
-    private ArrayList<String> getPresentPrefixes(ArgumentMultimap argumentMultimap, String... prefixes) {
-        ArrayList<String> presentPrefixes = new ArrayList<>();
-        for (String prefix : prefixes) {
-            if (argumentMultimap.getAllValues(new Prefix(prefix)).size() != 0) {
-                presentPrefixes.add(prefix);
-            } else {
-            }
-        }
-        return presentPrefixes;
     }
 
     private boolean hasValidPrefixCombination(ArrayList<String> prefixes) {

--- a/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
@@ -159,4 +159,24 @@ public class ParserUtil {
         return indicatedList;
     }
 
+    /**
+     * searches through the input string for for prefixes and returns the prefix that has the
+     * last occurence
+     * returns null if not found
+     */
+    public static Prefix getLastPrefix(String stringToSearch, Prefix...prefixes) {
+        // to deal with cases with prefix right at end or start
+        String extendedSearchString = " " + stringToSearch + " ";
+        Prefix foundPrefix = null;
+        int maxIndex = 0;
+        for (Prefix prefix : prefixes) {
+            Integer lastOccurence = extendedSearchString.lastIndexOf(" " + prefix + " ");
+            if (lastOccurence > maxIndex) {
+                maxIndex = lastOccurence;
+                foundPrefix = prefix;
+            }
+        }
+        return foundPrefix;
+    }
+
 }


### PR DESCRIPTION
Changelog 📜 
- implement smart parsing for add commands.
- `from`,`at`,`on` can be used alone to signify events, currently adding a magic number 1 hour for endDate, will update to config addDurationHour when its ready.
- `to` and `by` must be used together with a start date if user wants to add event with his specified enddate
- update to parsing logic, can now use any combination of flags to denote event as long as start and end is given, parser will only take the last end and start flag. e.g `add someevent from thursday by noon to 1 day by 6000 years ago on wat from today to tomorrow` will use `from today` and `to tomorrow`

- moved one of mattheus's method to ArgumentMultimap to allow reuse for my other parsers, update collated tag and listcommandparser to follow

Fixes #182 