### PR TITLE
V0.4 logictest refinement

### DIFF
--- a/src/main/java/seedu/multitasky/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/AddCommand.java
@@ -34,6 +34,8 @@ public class AddCommand extends Command {
                                                    CliSyntax.PREFIX_TO.toString(),
                                                    CliSyntax.PREFIX_TAG.toString()};
 
+    public static final String MESSAGE_ENDDATE_BEFORE_STARTDATE = "Can not have end date before start date!";
+
     private final ReadOnlyEntry toAdd;
 
     /**

--- a/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
@@ -59,7 +59,7 @@ public abstract class EditCommand extends Command {
 
     public static final String MESSAGE_DUPLICATE_ENTRY = "This entry already exists in the task manager.";
 
-    public static final String MESSAGE_ENDDATE_AFTER_STARTDATE = "Can not have end date before start date!";
+    public static final String MESSAGE_ENDDATE_BEFORE_STARTDATE = "Can not have end date before start date!";
 
     public static final String[] VALID_PREFIXES = {CliSyntax.PREFIX_EVENT.toString(),
                                                    CliSyntax.PREFIX_DEADLINE.toString(),
@@ -105,7 +105,7 @@ public abstract class EditCommand extends Command {
             return new Deadline(updatedName, updatedEndDate, updatedTags);
         } else if (updatedStartDate != null && updatedEndDate != null) {
             if (updatedEndDate.compareTo(updatedStartDate) < 0) {
-                throw new CommandException(MESSAGE_ENDDATE_AFTER_STARTDATE);
+                throw new CommandException(MESSAGE_ENDDATE_BEFORE_STARTDATE);
             }
             return new Event(updatedName, updatedStartDate, updatedEndDate, updatedTags);
         } else {

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -9,8 +9,6 @@ import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_ON;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_TO;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Set;
 
@@ -167,17 +165,6 @@ public class AddCommandParser {
         assert argMultimap != null;
         return ParserUtil.areAllPrefixesPresent(argMultimap, PREFIX_BY)
                && (!ParserUtil.arePrefixesPresent(argMultimap, PREFIX_AT, PREFIX_ON, PREFIX_FROM, PREFIX_TO));
-    }
-
-    /**
-     * A method that returns false if flags are given in an illogical manner for add commands.
-     */
-    private boolean hasValidPrefixCombination(ArrayList<String> prefixes) {
-        // Cannot have any unknown prefixes
-        if (!Arrays.asList(AddCommand.VALID_PREFIXES).containsAll(prefixes)) {
-            return false;
-        }
-        return true;
     }
 
     private Prefix[] toPrefixArray(String... stringPrefixes) {

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -52,12 +52,6 @@ public class AddCommandParser {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
 
-        // TODO check whether i need this or not. not really apt anymore for smart command parsing
-        ArrayList<String> prefixesPresent = argMultimap.getPresentPrefixes(AddCommand.VALID_PREFIXES);
-        if (!hasValidPrefixCombination(prefixesPresent)) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        }
-
         if (isFloatingTask()) {
             try {
                 Name name = ParserUtil.parseName(argMultimap.getPreamble()).get();
@@ -95,7 +89,7 @@ public class AddCommandParser {
                 endDate = ParserUtil.parseDate(argMultimap.getValue(endDatePrefix).get());
                 startDate = ParserUtil.parseDate(argMultimap.getValue(startDatePrefix).get());
                 if (endDate.compareTo(startDate) < 0) {
-                    throw new ParseException("End date should not be before start date!");
+                    throw new ParseException(AddCommand.MESSAGE_ENDDATE_BEFORE_STARTDATE);
                 }
                 Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
                 ReadOnlyEntry entry = new Event(name, startDate, endDate, tagList);
@@ -116,7 +110,7 @@ public class AddCommandParser {
                 // TODO implement import from config
                 endDate.add(Calendar.HOUR, 1);
                 if (endDate.compareTo(startDate) < 0) {
-                    throw new ParseException("End date should not be before start date!");
+                    throw new ParseException(AddCommand.MESSAGE_ENDDATE_BEFORE_STARTDATE);
                 }
                 Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
                 ReadOnlyEntry entry = new Event(name, startDate, endDate, tagList);

--- a/src/test/java/seedu/multitasky/logic/commands/DeleteByFindCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/DeleteByFindCommandTest.java
@@ -1,0 +1,117 @@
+package seedu.multitasky.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+
+import seedu.multitasky.logic.CommandHistory;
+import seedu.multitasky.model.Model;
+import seedu.multitasky.model.ModelManager;
+import seedu.multitasky.model.UserPrefs;
+import seedu.multitasky.model.entry.Entry;
+import seedu.multitasky.model.entry.ReadOnlyEntry;
+import seedu.multitasky.model.util.EntryBuilder;
+import seedu.multitasky.testutil.SampleEntries;
+
+// @@author A0140633R
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for {@code DeleteByFindCommand}.
+ */
+public class DeleteByFindCommandTest {
+
+    @Test
+    public void execute_validKeywordsUnfilteredList_success() throws Exception {
+        Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+
+        ReadOnlyEntry entryToDelete = model.getFilteredFloatingTaskList()
+                                           .get(INDEX_FIRST_ENTRY.getZeroBased());
+
+        String searchString = entryToDelete.getName().fullName.replaceAll("\\\\", "");
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+
+        DeleteCommand deleteCommand = prepareCommand(model, keywords);
+        String expectedMessage = String.format(DeleteByFindCommand.MESSAGE_SUCCESS, entryToDelete);
+        ModelManager expectedModel = new ModelManager(model.getEntryBook(), new UserPrefs());
+
+        CommandResult result = deleteCommand.execute();
+        assertEquals(result.feedbackToUser, expectedMessage);
+
+        expectedModel.changeEntryState(entryToDelete, Entry.State.DELETED);
+        expectedModel.updateAllFilteredListToShowAllActiveEntries();
+        assertEquals(model, expectedModel);
+    }
+
+    @Test
+    public void execute_noEntryFoundUnfilteredList_returnsNoEntriesMessage() throws Exception {
+        Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        String searchString = "try to find";
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        DeleteCommand deleteCommand = prepareCommand(model, keywords);
+        CommandResult result = deleteCommand.execute();
+
+        assertEquals(result.feedbackToUser, DeleteByFindCommand.MESSAGE_NO_ENTRIES);
+    }
+
+    @Test
+    public void execute_multipleEntriesFoundFilteredList_returnsMultipleEntriesMessage() throws Exception {
+        Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        String searchString = "try to find";
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        model.addEntry(EntryBuilder.build(searchString + " 1", "first_tag"));
+        model.addEntry(EntryBuilder.build(searchString + " 2", "second_tag"));
+        model.addEntry(EntryBuilder.build(searchString + " 3", "third_tag"));
+        DeleteCommand deleteCommand = prepareCommand(model, keywords);
+        CommandResult result = deleteCommand.execute();
+
+        assertEquals(result.feedbackToUser, DeleteByFindCommand.MESSAGE_MULTIPLE_ENTRIES);
+    }
+
+    @Test
+    public void execute_validKeywordsFilteredList_success() throws Exception {
+        Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+
+        showFirstEntryOnly(model);
+        ReadOnlyEntry entryToDelete = model.getFilteredFloatingTaskList()
+                                           .get(INDEX_FIRST_ENTRY.getZeroBased());
+
+        String searchString = entryToDelete.getName().fullName.replaceAll("\\\\", "");
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+
+        DeleteCommand deleteCommand = prepareCommand(model, keywords);
+        String expectedMessage = String.format(DeleteByFindCommand.MESSAGE_SUCCESS, entryToDelete);
+        ModelManager expectedModel = new ModelManager(model.getEntryBook(), new UserPrefs());
+
+        CommandResult result = deleteCommand.execute();
+        assertEquals(result.feedbackToUser, expectedMessage);
+
+        expectedModel.changeEntryState(entryToDelete, Entry.State.DELETED);
+        expectedModel.updateAllFilteredListToShowAllActiveEntries();
+        assertEquals(model, expectedModel);
+    }
+
+    /**
+     * Returns a {@code DeleteCommand} with the parameter {@code index}.
+     */
+    private DeleteCommand prepareCommand(Model model, Set<String> keywords) {
+        DeleteCommand deleteCommand = new DeleteByFindCommand(keywords);
+        deleteCommand.setData(model, new CommandHistory());
+        return deleteCommand;
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show only the first entry from the entry book.
+     */
+    private void showFirstEntryOnly(Model model) {
+        ReadOnlyEntry entry = model.getEntryBook().getFloatingTaskList().get(0);
+        final String[] splitName = entry.getName().fullName.split("\\s+");
+        model.updateFilteredFloatingTaskList(new HashSet<>(Arrays.asList(splitName)), Entry.State.ACTIVE);
+
+        assert model.getFilteredFloatingTaskList().size() == 1;
+    }
+
+}

--- a/src/test/java/seedu/multitasky/logic/commands/EditByFindCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditByFindCommandTest.java
@@ -1,0 +1,205 @@
+package seedu.multitasky.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FLOATINGTASK;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_MEETING;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_11_JULY_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_12_JULY_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_20_DEC_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_MEETING;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_URGENT;
+import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
+import static seedu.multitasky.testutil.SampleEntries.INDEX_SECOND_ENTRY;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Test;
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
+import seedu.multitasky.logic.CommandHistory;
+import seedu.multitasky.logic.commands.EditCommand.EditEntryDescriptor;
+import seedu.multitasky.model.EntryBook;
+import seedu.multitasky.model.Model;
+import seedu.multitasky.model.ModelManager;
+import seedu.multitasky.model.UserPrefs;
+import seedu.multitasky.model.entry.Entry;
+import seedu.multitasky.model.entry.Name;
+import seedu.multitasky.model.entry.ReadOnlyEntry;
+import seedu.multitasky.model.util.EntryBuilder;
+import seedu.multitasky.testutil.EditEntryDescriptorBuilder;
+import seedu.multitasky.testutil.SampleEntries;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditByIndexCommand.
+ */
+public class EditByFindCommandTest {
+
+    private Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+
+    // @@author A0140633R
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws Exception {
+        String searchString = model.getFilteredEventList().get(0).getName().fullName;
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_12_JULY_17),
+                parseDate(VALID_DATE_20_DEC_17), VALID_TAG_URGENT, VALID_TAG_FRIEND);
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
+                .withName(VALID_NAME_CLEAN).withStartDate(VALID_DATE_12_JULY_17).withEndDate(VALID_DATE_20_DEC_17)
+                .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
+        EditCommand editCommand = prepareCommand(model, keywords, descriptor);
+        String expectedMessage = String.format(EditByFindCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        expectedModel.updateEntry(expectedModel.getFilteredEventList().get(INDEX_FIRST_ENTRY.getZeroBased()),
+                                  editedEntry);
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+    // @@author A0140633R
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() throws Exception {
+        String searchString = model.getFilteredDeadlineList().get(0).getName().fullName;
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_11_JULY_17),
+                                               VALID_TAG_URGENT, VALID_TAG_FRIEND);
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
+                .withName(VALID_NAME_CLEAN).withEndDate(VALID_DATE_11_JULY_17)
+                .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
+        EditCommand editCommand = prepareCommand(model, keywords, descriptor);
+        String expectedMessage = String.format(EditByFindCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        expectedModel.updateEntry(expectedModel.getFilteredDeadlineList().get(INDEX_FIRST_ENTRY.getZeroBased()),
+                                  editedEntry);
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() throws Exception {
+        showFirstEntryOnly();
+        ReadOnlyEntry entryInFilteredList = model.getFilteredFloatingTaskList()
+                                                 .get(INDEX_FIRST_ENTRY.getZeroBased());
+        String searchString = entryInFilteredList.getName().fullName;
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        Entry editedEntry = EntryBuilder.build();
+        editedEntry.setName(new Name(VALID_NAME_MEETING));
+        editedEntry.setTags(entryInFilteredList.getTags());
+        EditCommand editCommand = prepareCommand(model, keywords,
+                new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING).build());
+        String expectedMessage = String.format(EditByFindCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(new EntryBook(model.getEntryBook()), new UserPrefs());
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    // @@author A0140633R
+    @Test
+    public void execute_multipleEntriesFound_returnsMultipleEntriesMessage() throws Exception {
+        String searchString = "try to find";
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        model.addEntry(EntryBuilder.build(searchString + " 1", "first_tag"));
+        model.addEntry(EntryBuilder.build(searchString + " 2", "second_tag"));
+        model.addEntry(EntryBuilder.build(searchString + " 3", "third_tag"));
+        EditEntryDescriptor editEntryDescriptor = new EditEntryDescriptor();
+        EditCommand editCommand = prepareCommand(model, keywords, editEntryDescriptor);
+        String expectedMessage = EditByFindCommand.MESSAGE_MULTIPLE_ENTRIES;
+
+        CommandResult result = editCommand.execute();
+        assertEquals(result.feedbackToUser, expectedMessage);
+    }
+
+    @Test
+    public void execute_noEntriesFound_returnsNoEntriesMessage() throws Exception {
+        String searchString = "try to find";
+        HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
+        EditEntryDescriptor editEntryDescriptor = new EditEntryDescriptor();
+        EditCommand editCommand = prepareCommand(model, keywords, editEntryDescriptor);
+        String expectedMessage = EditByFindCommand.MESSAGE_NO_ENTRIES;
+
+        CommandResult result = editCommand.execute();
+        assertEquals(result.feedbackToUser, expectedMessage);
+    }
+    // @@author A0140633R
+
+    @Test
+    public void equals() {
+        final EditCommand standardCommand = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                   DESC_CLEAN);
+
+        // same values -> returns true
+        EditEntryDescriptor copyDescriptor = new EditEntryDescriptor(DESC_CLEAN);
+        EditCommand commandWithSameValues = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                   copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_SECOND_ENTRY, PREFIX_FLOATINGTASK,
+                                                                  DESC_CLEAN)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                  DESC_MEETING)));
+    }
+
+    /**
+     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}
+     */
+    private EditCommand prepareCommand(Model model, Set<String> keywords,
+                                       EditEntryDescriptor editEntryDescriptor) {
+        EditCommand editCommand = new EditByFindCommand(keywords, editEntryDescriptor);
+        editCommand.setData(model, new CommandHistory());
+        return editCommand;
+    }
+
+    /**
+     * Updates the filtered list to show only the first entry in the {@code model}'s entry book.
+     */
+    private void showFirstEntryOnly() {
+        ReadOnlyEntry entry = model.getEntryBook().getFloatingTaskList().get(0);
+        final String[] splitName = entry.getName().fullName.split("\\s+");
+        model.updateFilteredFloatingTaskList(new HashSet<>(Arrays.asList(splitName)), Entry.State.ACTIVE);
+
+        assertTrue(model.getFilteredFloatingTaskList().size() == 1);
+    }
+
+    /**
+     * Converts date to a calendar
+     */
+    private Calendar parseDate(String args) throws Exception {
+        PrettyTimeParser ptp = new PrettyTimeParser();
+        Calendar calendar = new GregorianCalendar();
+        try {
+            List<Date> dates = ptp.parse(args);
+            Date date = dates.get(0);
+            calendar.setTime(date);
+            return calendar;
+
+        } catch (Exception e) {
+            // double exception catching as a fail-safe
+            fail("should not give invalid dates to parse");
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/seedu/multitasky/logic/commands/EditByIndexCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditByIndexCommandTest.java
@@ -1,0 +1,202 @@
+package seedu.multitasky.logic.commands;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_DEADLINE;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_EVENT;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FLOATINGTASK;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_MEETING;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_11_JULY_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_12_JULY_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_20_DEC_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_MEETING;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_URGENT;
+import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
+import static seedu.multitasky.testutil.SampleEntries.INDEX_SECOND_ENTRY;
+
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
+import seedu.multitasky.commons.core.Messages;
+import seedu.multitasky.commons.core.index.Index;
+import seedu.multitasky.logic.CommandHistory;
+import seedu.multitasky.logic.commands.EditCommand.EditEntryDescriptor;
+import seedu.multitasky.logic.parser.Prefix;
+import seedu.multitasky.model.EntryBook;
+import seedu.multitasky.model.Model;
+import seedu.multitasky.model.ModelManager;
+import seedu.multitasky.model.UserPrefs;
+import seedu.multitasky.model.entry.Entry;
+import seedu.multitasky.model.entry.Name;
+import seedu.multitasky.model.entry.ReadOnlyEntry;
+import seedu.multitasky.model.util.EntryBuilder;
+import seedu.multitasky.testutil.EditEntryDescriptorBuilder;
+import seedu.multitasky.testutil.SampleEntries;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditByIndexCommand.
+ */
+public class EditByIndexCommandTest {
+
+    private Model model = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+
+    // @@author A0140633R
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() throws Exception {
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_12_JULY_17),
+                parseDate(VALID_DATE_20_DEC_17), VALID_TAG_URGENT, VALID_TAG_FRIEND);
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
+                .withName(VALID_NAME_CLEAN).withStartDate(VALID_DATE_12_JULY_17).withEndDate(VALID_DATE_20_DEC_17)
+                .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
+        EditCommand editCommand = prepareCommand(INDEX_FIRST_ENTRY, PREFIX_EVENT, descriptor);
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        expectedModel.updateEntry(expectedModel.getFilteredEventList().get(INDEX_FIRST_ENTRY.getZeroBased()),
+                                  editedEntry);
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+    // @@author A0140633R
+
+    @Test
+    public void execute_someFieldsSpecifiedUnfilteredList_success() throws Exception {
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_11_JULY_17),
+                                               VALID_TAG_URGENT, VALID_TAG_FRIEND);
+        EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
+                .withName(VALID_NAME_CLEAN).withEndDate(VALID_DATE_11_JULY_17)
+                .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
+        EditCommand editCommand = prepareCommand(INDEX_FIRST_ENTRY, PREFIX_DEADLINE, descriptor);
+        String expectedMessage = String.format(EditCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
+        expectedModel.updateEntry(expectedModel.getFilteredDeadlineList().get(INDEX_FIRST_ENTRY.getZeroBased()),
+                                  editedEntry);
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_filteredList_success() throws Exception {
+        showFirstEntryOnly();
+        ReadOnlyEntry entryInFilteredList = model.getFilteredFloatingTaskList()
+                                                 .get(INDEX_FIRST_ENTRY.getZeroBased());
+        Entry editedEntry = EntryBuilder.build();
+        editedEntry.setName(new Name(VALID_NAME_MEETING));
+        editedEntry.setTags(entryInFilteredList.getTags());
+        EditCommand editCommand = prepareCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING).build());
+        String expectedMessage = String.format(EditByIndexCommand.MESSAGE_SUCCESS, editedEntry);
+        Model expectedModel = new ModelManager(new EntryBook(model.getEntryBook()), new UserPrefs());
+
+        CommandTestUtil.assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidEntryIndexUnfilteredList_failure() throws Exception {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredFloatingTaskList().size() + 1);
+        EditEntryDescriptor descriptor =
+                                       new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING).build();
+        EditCommand editCommand = prepareCommand(outOfBoundIndex, PREFIX_FLOATINGTASK, descriptor);
+
+        CommandTestUtil.assertCommandFailure(editCommand, model,
+                                             Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Edit filtered list where index is larger than size of filtered list,
+     * but smaller than size of entry book
+     */
+    @Test
+    public void execute_invalidEntryIndexFilteredList_failure() throws Exception {
+        showFirstEntryOnly();
+        Index outOfBoundIndex = INDEX_SECOND_ENTRY;
+        // ensures that outOfBoundIndex is still in bounds of entry book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getEntryBook().getFloatingTaskList().size());
+
+        EditCommand editCommand = prepareCommand(outOfBoundIndex, PREFIX_FLOATINGTASK,
+                                                 new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING)
+                                                                                 .build());
+
+        CommandTestUtil.assertCommandFailure(editCommand, model,
+                                             Messages.MESSAGE_INVALID_ENTRY_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void equals() {
+        final EditCommand standardCommand = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                   DESC_CLEAN);
+
+        // same values -> returns true
+        EditEntryDescriptor copyDescriptor = new EditEntryDescriptor(DESC_CLEAN);
+        EditCommand commandWithSameValues = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                   copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_SECOND_ENTRY, PREFIX_FLOATINGTASK,
+                                                                  DESC_CLEAN)));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
+                                                                  DESC_MEETING)));
+    }
+
+    /**
+     * Returns an {@code EditCommand} with parameters {@code index} and {@code descriptor}
+     */
+    private EditCommand prepareCommand(Index index, Prefix prefix , EditEntryDescriptor descriptor) {
+        EditCommand editCommand = new EditByIndexCommand(index, prefix, descriptor);
+        editCommand.setData(model, new CommandHistory());
+        return editCommand;
+    }
+
+    /**
+     * Updates the filtered list to show only the first entry in the {@code model}'s entry book.
+     */
+    private void showFirstEntryOnly() {
+        ReadOnlyEntry entry = model.getEntryBook().getFloatingTaskList().get(0);
+        final String[] splitName = entry.getName().fullName.split("\\s+");
+        model.updateFilteredFloatingTaskList(new HashSet<>(Arrays.asList(splitName)), Entry.State.ACTIVE);
+
+        assertTrue(model.getFilteredFloatingTaskList().size() == 1);
+    }
+
+    /**
+     * Converts date to a calendar
+     */
+    private Calendar parseDate(String args) throws Exception {
+        PrettyTimeParser ptp = new PrettyTimeParser();
+        Calendar calendar = new GregorianCalendar();
+        try {
+            List<Date> dates = ptp.parse(args);
+            Date date = dates.get(0);
+            calendar.setTime(date);
+            return calendar;
+
+        } catch (Exception e) {
+            // double exception catching as a fail-safe
+            fail("should not give invalid dates to parse");
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/seedu/multitasky/logic/commands/EditCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditCommandTest.java
@@ -3,8 +3,8 @@ package seedu.multitasky.logic.commands;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FLOATINGTASK;
-import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_AMY;
-import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_BOB;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_MEETING;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_MEETING;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_SECOND_ENTRY;
@@ -125,10 +125,10 @@ public class EditCommandTest {
     @Test
     public void equals() {
         final EditCommand standardCommand = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
-                                                                   DESC_AMY);
+                                                                   DESC_CLEAN);
 
         // same values -> returns true
-        EditEntryDescriptor copyDescriptor = new EditEntryDescriptor(DESC_AMY);
+        EditEntryDescriptor copyDescriptor = new EditEntryDescriptor(DESC_CLEAN);
         EditCommand commandWithSameValues = new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
                                                                    copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
@@ -144,11 +144,11 @@ public class EditCommandTest {
 
         // different index -> returns false
         assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_SECOND_ENTRY, PREFIX_FLOATINGTASK,
-                                                                  DESC_AMY)));
+                                                                  DESC_CLEAN)));
 
         // different descriptor -> returns false
         assertFalse(standardCommand.equals(new EditByIndexCommand(INDEX_FIRST_ENTRY, PREFIX_FLOATINGTASK,
-                                                                  DESC_BOB)));
+                                                                  DESC_MEETING)));
     }
 
     /**

--- a/src/test/java/seedu/multitasky/logic/commands/EditEntryDescriptorTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditEntryDescriptorTest.java
@@ -2,8 +2,8 @@ package seedu.multitasky.logic.commands;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_AMY;
-import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_BOB;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_CLEAN;
+import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_MEETING;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_MEETING;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_URGENT;
 
@@ -17,27 +17,27 @@ public class EditEntryDescriptorTest {
     @Test
     public void equals() throws Exception {
         // same values -> returns true
-        EditEntryDescriptor descriptorWithSameValues = new EditEntryDescriptor(DESC_AMY);
-        assertTrue(DESC_AMY.equals(descriptorWithSameValues));
+        EditEntryDescriptor descriptorWithSameValues = new EditEntryDescriptor(DESC_CLEAN);
+        assertTrue(DESC_CLEAN.equals(descriptorWithSameValues));
 
         // same object -> returns true
-        assertTrue(DESC_AMY.equals(DESC_AMY));
+        assertTrue(DESC_CLEAN.equals(DESC_CLEAN));
 
         // null -> returns false
-        assertFalse(DESC_AMY.equals(null));
+        assertFalse(DESC_CLEAN.equals(null));
 
         // different types -> returns false
-        assertFalse(DESC_AMY.equals(5));
+        assertFalse(DESC_CLEAN.equals(5));
 
         // different values -> returns false
-        assertFalse(DESC_AMY.equals(DESC_BOB));
+        assertFalse(DESC_CLEAN.equals(DESC_MEETING));
 
         // different name -> returns false
-        EditEntryDescriptor editedAmy = new EditEntryDescriptorBuilder(DESC_AMY).withName(VALID_NAME_MEETING).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        EditEntryDescriptor editedAmy = new EditEntryDescriptorBuilder(DESC_CLEAN).withName(VALID_NAME_MEETING).build();
+        assertFalse(DESC_CLEAN.equals(editedAmy));
 
         // different tags -> returns false
-        editedAmy = new EditEntryDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_URGENT).build();
-        assertFalse(DESC_AMY.equals(editedAmy));
+        editedAmy = new EditEntryDescriptorBuilder(DESC_CLEAN).withTags(VALID_TAG_URGENT).build();
+        assertFalse(DESC_CLEAN.equals(editedAmy));
     }
 }

--- a/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
@@ -1,0 +1,105 @@
+package seedu.multitasky.logic.parser;
+
+import static org.junit.Assert.assertTrue;
+import static seedu.multitasky.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_AT;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_BY;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FROM;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_ON;
+import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_TO;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import seedu.multitasky.logic.commands.AddCommand;
+import seedu.multitasky.logic.commands.Command;
+import seedu.multitasky.logic.parser.exceptions.ParseException;
+
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the AddCommand code. For example, inputs " float 1" and " float 1 abc" take the
+ * same path through the AddCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class AddCommandParserTest {
+    private static final String VALID_DATE_17JULY = "17 july 2017";
+    private static final String VALID_DATE_20JULY = "20 july 2017";
+    private static final String INVALID_DATE = "end of time";
+
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private AddCommandParser parser = new AddCommandParser();
+
+    //@A0140633R
+    @Test
+    public void parse_emptyArgs_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        parser.parse("");
+    }
+
+    @Test
+    public void parse_validArgs_returnsAddCommand() throws Exception {
+        // floating task
+        Command command = parser.parse(" a typical task name");
+        assertTrue(command instanceof AddCommand);
+        command = parser.parse(" a special task with \\by in its name");
+        assertTrue(command instanceof AddCommand);
+
+        // deadline
+        command = parser.parse(" a typical task with enddate " + PREFIX_BY
+                               + " " + VALID_DATE_17JULY);
+        assertTrue(command instanceof AddCommand);
+        command = parser.parse(" a special task with enddate and \\by in name "
+                               + PREFIX_BY + " " + VALID_DATE_17JULY);
+        assertTrue(command instanceof AddCommand);
+
+        // event
+        command = parser.parse(" a typical task with both start and end date " + PREFIX_FROM + " "
+                               + VALID_DATE_17JULY + " " + PREFIX_TO + " " + VALID_DATE_20JULY);
+        assertTrue(command instanceof AddCommand);
+        command = parser.parse(" a special task with many start date and end date " + PREFIX_FROM + " "
+                + VALID_DATE_17JULY + " " + PREFIX_AT + " " + VALID_DATE_17JULY + PREFIX_TO + " " + VALID_DATE_20JULY);
+        assertTrue(command instanceof AddCommand);
+        // only start date variant event
+        command = parser.parse(" a special task with only start date " + PREFIX_FROM + " " + VALID_DATE_17JULY);
+        assertTrue(command instanceof AddCommand);
+        command = parser.parse(" a special task with only start date " + PREFIX_AT + " " + VALID_DATE_20JULY);
+        assertTrue(command instanceof AddCommand);
+    }
+
+    public void parse_invalidArgsFollowedByValidArgs_returnsAddCommand() throws Exception {
+        Command command = parser.parse(" a special task with many start date and end date " + PREFIX_FROM + " "
+                + INVALID_DATE + " " + PREFIX_AT + " " + VALID_DATE_17JULY + PREFIX_TO
+                + " " + VALID_DATE_20JULY);
+        assertTrue(command instanceof AddCommand);
+    }
+
+    @Test
+    public void parse_invalidDate_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(ParserUtil.MESSAGE_FAIL_PARSE_DATE, INVALID_DATE));
+        parser.parse("task with invalid date " + PREFIX_BY + " " + INVALID_DATE);
+    }
+
+    @Test
+    public void parse_invalidFlagCombination_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
+        parser.parse("task with only \\to flag " + PREFIX_TO + " " + VALID_DATE_17JULY);
+    }
+
+    @Test
+    public void parse_eventEndDateBeforeStartDate_throwsParseException() throws Exception {
+        thrown.expect(ParseException.class);
+        thrown.expectMessage(AddCommand.MESSAGE_ENDDATE_BEFORE_STARTDATE);
+        parser.parse("task with enddate before startdate " + PREFIX_ON + " " + VALID_DATE_20JULY
+                     + " " + PREFIX_TO + " " + VALID_DATE_17JULY);
+    }
+
+}

--- a/src/test/java/seedu/multitasky/testutil/EditCommandTestUtil.java
+++ b/src/test/java/seedu/multitasky/testutil/EditCommandTestUtil.java
@@ -16,14 +16,14 @@ public class EditCommandTestUtil {
     public static final String VALID_DATE_11_JULY_17 = "11 july 17";
     public static final String VALID_DATE_20_DEC_17 = "12 dec 17";
 
-    public static final EditEntryDescriptor DESC_AMY;
-    public static final EditEntryDescriptor DESC_BOB;
+    public static final EditEntryDescriptor DESC_CLEAN;
+    public static final EditEntryDescriptor DESC_MEETING;
 
     static {
         try {
-            DESC_AMY = new EditEntryDescriptorBuilder().withName(VALID_NAME_CLEAN)
+            DESC_CLEAN = new EditEntryDescriptorBuilder().withName(VALID_NAME_CLEAN)
                     .withTags(VALID_TAG_FRIEND).build();
-            DESC_BOB = new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING)
+            DESC_MEETING = new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING)
                     .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
         } catch (IllegalValueException ive) {
             throw new AssertionError("Method should not fail.");


### PR DESCRIPTION
Just an update to outdated logic tests.
add tests for `ByFind` variant of delete, edit commands.
add tests for new `AddCommandParser` paths