### PR TITLE
V0.4 Smoothen UI Update When Entries Change

### DIFF
--- a/src/main/java/seedu/multitasky/logic/commands/CompleteByFindCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/CompleteByFindCommand.java
@@ -62,7 +62,8 @@ public class CompleteByFindCommand extends CompleteCommand {
                 assert false : "The target entry cannot be missing";
             }
             // refresh list view after updating.
-            model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+            model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                         history.getPrevEndDate(), history.getPrevState());
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, entryToComplete));
         } else {

--- a/src/main/java/seedu/multitasky/logic/commands/CompleteByIndexCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/CompleteByIndexCommand.java
@@ -42,7 +42,8 @@ public class CompleteByIndexCommand extends CompleteCommand {
             assert false : "The target entry cannot be missing";
         }
         // refresh list view after updating.
-        model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+        model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                     history.getPrevEndDate(), history.getPrevState());
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, entryToComplete));
     }

--- a/src/main/java/seedu/multitasky/logic/commands/DeleteByFindCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/DeleteByFindCommand.java
@@ -62,7 +62,8 @@ public class DeleteByFindCommand extends DeleteCommand {
                 assert false : "The target entry cannot be missing";
             }
             // refresh list view after updating.
-            model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+            model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                         history.getPrevEndDate(), history.getPrevState());
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, entryToDelete));
         } else {

--- a/src/main/java/seedu/multitasky/logic/commands/DeleteByIndexCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/DeleteByIndexCommand.java
@@ -42,7 +42,8 @@ public class DeleteByIndexCommand extends DeleteCommand {
             assert false : "The target entry cannot be missing";
         }
         // refresh list view after updating.
-        model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+        model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                     history.getPrevEndDate(), history.getPrevState());
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, entryToDelete));
     }

--- a/src/main/java/seedu/multitasky/logic/commands/EditByFindCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/EditByFindCommand.java
@@ -64,7 +64,8 @@ public class EditByFindCommand extends EditCommand {
                 assert false : "The target entry cannot be missing";
             }
             // refresh list view after updating.
-            model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+            model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                         history.getPrevEndDate(), history.getPrevState());
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, entryToEdit));
         } else {

--- a/src/main/java/seedu/multitasky/logic/commands/EditByIndexCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/EditByIndexCommand.java
@@ -51,7 +51,8 @@ public class EditByIndexCommand extends EditCommand {
             model.updateEntry(entryToEdit, editedEntry);
 
             // refresh list view after updating
-            model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+            model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                         history.getPrevEndDate(), history.getPrevState());
 
         } catch (EntryNotFoundException pnfe) {
             throw new AssertionError("The target entry cannot be missing");

--- a/src/main/java/seedu/multitasky/logic/commands/RestoreByFindCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/RestoreByFindCommand.java
@@ -58,8 +58,8 @@ public class RestoreByFindCommand extends RestoreCommand {
             }
 
             // refresh list view after updating.
-            model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
-            history.setPrevSearch(keywords, null, null, history.getPrevState());
+            model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                         history.getPrevEndDate(), history.getPrevState());
 
             return new CommandResult(String.format(MESSAGE_SUCCESS, entryToRestore));
         } else {

--- a/src/main/java/seedu/multitasky/logic/commands/RestoreByIndexCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/RestoreByIndexCommand.java
@@ -50,7 +50,8 @@ public class RestoreByIndexCommand extends RestoreCommand {
         }
 
         // refresh list view after updating.
-        model.updateAllFilteredLists(history.getPrevSearch(), null, null, history.getPrevState());
+        model.updateAllFilteredLists(history.getPrevSearch(), history.getPrevStartDate(),
+                                     history.getPrevEndDate(), history.getPrevState());
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, entryToRestore));
     }


### PR DESCRIPTION
@CS2103JUN2017-T2/developers 
Please review if this makes sense. I'm trying to make MultiTasky not do a big 'reset' to the list the user last saw after he uses commands that changes an entry's state. E.g. if the last seen list is within a defined time window, it shouldn't refresh and list entries without time bound.