### PR TITLE
V0.5rc preferencejson and startdate equal enddate

### DIFF
--- a/src/main/java/seedu/multitasky/MainApp.java
+++ b/src/main/java/seedu/multitasky/MainApp.java
@@ -68,7 +68,7 @@ public class MainApp extends Application {
 
         model = initModelManager(storage, userPrefs);
 
-        logic = new LogicManager(model);
+        logic = new LogicManager(model, userPrefs);
 
         ui = new UiManager(logic, config, userPrefs);
 

--- a/src/main/java/seedu/multitasky/logic/LogicManager.java
+++ b/src/main/java/seedu/multitasky/logic/LogicManager.java
@@ -10,6 +10,7 @@ import seedu.multitasky.logic.commands.CommandResult;
 import seedu.multitasky.logic.commands.exceptions.CommandException;
 import seedu.multitasky.logic.parser.Parser;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
+import seedu.multitasky.model.LogicUserPrefs;
 import seedu.multitasky.model.Model;
 import seedu.multitasky.model.UserPrefs;
 import seedu.multitasky.model.entry.ReadOnlyEntry;
@@ -24,7 +25,7 @@ public class LogicManager extends ComponentManager implements Logic {
     private final Model model;
     private final CommandHistory history;
     private final Parser parser;
-    private final UserPrefs userprefs;
+    private final LogicUserPrefs userprefs;
 
     public LogicManager(Model model, UserPrefs userprefs) {
         this.model = model;

--- a/src/main/java/seedu/multitasky/logic/LogicManager.java
+++ b/src/main/java/seedu/multitasky/logic/LogicManager.java
@@ -12,7 +12,6 @@ import seedu.multitasky.logic.parser.Parser;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
 import seedu.multitasky.model.LogicUserPrefs;
 import seedu.multitasky.model.Model;
-import seedu.multitasky.model.UserPrefs;
 import seedu.multitasky.model.entry.ReadOnlyEntry;
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
 
@@ -27,7 +26,7 @@ public class LogicManager extends ComponentManager implements Logic {
     private final Parser parser;
     private final LogicUserPrefs userprefs;
 
-    public LogicManager(Model model, UserPrefs userprefs) {
+    public LogicManager(Model model, LogicUserPrefs userprefs) {
         this.model = model;
         this.userprefs = userprefs;
         this.history = new CommandHistory();

--- a/src/main/java/seedu/multitasky/logic/LogicManager.java
+++ b/src/main/java/seedu/multitasky/logic/LogicManager.java
@@ -11,6 +11,7 @@ import seedu.multitasky.logic.commands.exceptions.CommandException;
 import seedu.multitasky.logic.parser.Parser;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
 import seedu.multitasky.model.Model;
+import seedu.multitasky.model.UserPrefs;
 import seedu.multitasky.model.entry.ReadOnlyEntry;
 import seedu.multitasky.model.entry.exceptions.DuplicateEntryException;
 
@@ -23,9 +24,11 @@ public class LogicManager extends ComponentManager implements Logic {
     private final Model model;
     private final CommandHistory history;
     private final Parser parser;
+    private final UserPrefs userprefs;
 
-    public LogicManager(Model model) {
+    public LogicManager(Model model, UserPrefs userprefs) {
         this.model = model;
+        this.userprefs = userprefs;
         this.history = new CommandHistory();
         this.parser = new Parser();
     }
@@ -35,7 +38,7 @@ public class LogicManager extends ComponentManager implements Logic {
     public CommandResult execute(String commandText) throws CommandException, ParseException, DuplicateEntryException {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
         try {
-            Command command = parser.parseCommand(commandText);
+            Command command = parser.parseCommand(commandText, userprefs);
             logger.info("User input successfully parsed into Command!");
             command.setData(model, history);
             return command.execute();

--- a/src/main/java/seedu/multitasky/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/AddCommand.java
@@ -27,6 +27,7 @@ public class AddCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "New entry added:" + "\n"
                                                  + Messages.MESSAGE_ENTRY_DESCRIPTION + "%1$s";
+
     public static final String MESSAGE_SUCCESS_WITH_OVERLAP_ALERT = "New entry added:" + "\n"
             + Messages.MESSAGE_ENTRY_DESCRIPTION + "%1$s" + "\n"
             + "Alert: New entry %1$s overlaps with existing event(s).";
@@ -37,6 +38,8 @@ public class AddCommand extends Command {
                                                    CliSyntax.PREFIX_ON.toString(),
                                                    CliSyntax.PREFIX_TO.toString(),
                                                    CliSyntax.PREFIX_TAG.toString()};
+
+    public static final String MESSAGE_INVALID_CONFIG_DURATION = "default addDuration cannot be zero or negative!";
 
     public static final String MESSAGE_ENDDATE_BEFORE_STARTDATE = "Can not have end date before start date!";
 

--- a/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
@@ -94,7 +94,8 @@ public abstract class EditCommand extends Command {
      * {@code entryToEdit} edited with {@code editEntryDescriptor}.
      */
     protected static Entry createEditedEntry(ReadOnlyEntry entryToEdit,
-            EditEntryDescriptor editEntryDescriptor) throws CommandException {
+                                             EditEntryDescriptor editEntryDescriptor)
+            throws CommandException {
         assert entryToEdit != null;
 
         Name updatedName = editEntryDescriptor.getName().orElse(entryToEdit.getName());
@@ -103,6 +104,15 @@ public abstract class EditCommand extends Command {
                                                        .orElse(entryToEdit.getStartDateAndTime());
         Calendar updatedEndDate = editEntryDescriptor.getEndDate()
                                                      .orElse(entryToEdit.getEndDateAndTime());
+        // set calendars for comparison purposes
+        if (updatedStartDate != null) {
+            updatedStartDate.set(Calendar.SECOND, 0);
+            updatedStartDate.set(Calendar.MILLISECOND, 0);
+        }
+        if (updatedEndDate != null) {
+            updatedEndDate.set(Calendar.SECOND, 0);
+            updatedEndDate.set(Calendar.MILLISECOND, 0);
+        }
 
         if (editToFloating(updatedStartDate, updatedEndDate) // floating task cases
             // deadline but reset end date
@@ -116,21 +126,22 @@ public abstract class EditCommand extends Command {
                    // event with start date removed
                    || (editToEvent(updatedStartDate, updatedEndDate))
                       && editEntryDescriptor.hasResetStartDate()
-                   // event with startdate == enddate
-                   || (editToEvent(updatedStartDate, updatedEndDate))
-                      && updatedEndDate.compareTo(updatedStartDate) == 0
-                   || editToEvent(updatedStartDate, updatedEndDate)
-                      && editEntryDescriptor.hasResetStartDate()
+                   // event with end date removed
                    || editToEvent(updatedStartDate, updatedEndDate)
                       && editEntryDescriptor.hasResetEndDate()) {
-            updatedEndDate = updatedEndDate == null ? updatedStartDate : updatedEndDate;
+            updatedEndDate = (updatedEndDate == null) ? updatedStartDate : updatedEndDate;
             return new Deadline(updatedName, updatedEndDate, updatedTags);
 
-        } else if (editToEvent(updatedStartDate, updatedEndDate)
-                   && editEntryDescriptor.hasResetStartDate()) {
-            return new Deadline(updatedName, updatedStartDate, updatedTags);
+        } else if (editToEvent(updatedStartDate, updatedEndDate) // event with start date == end date
+                   && updatedEndDate.compareTo(updatedStartDate) == 0) {
+            // convert automatically to full day event
+            updatedStartDate.set(Calendar.HOUR, 0);
+            updatedStartDate.set(Calendar.MINUTE, 0);
+            updatedEndDate.set(Calendar.HOUR, 23);
+            updatedEndDate.set(Calendar.MINUTE, 59);
+            return new Event(updatedName, updatedStartDate, updatedEndDate, updatedTags);
 
-        } else if (editToEvent(updatedStartDate, updatedEndDate)) { //events cases
+        } else if (editToEvent(updatedStartDate, updatedEndDate)) { // normal events cases
             if (updatedEndDate.compareTo(updatedStartDate) < 0) { // edited to invalid end date
                 throw new CommandException(MESSAGE_ENDDATE_BEFORE_STARTDATE);
             }
@@ -146,7 +157,7 @@ public abstract class EditCommand extends Command {
 
     private static boolean editToDeadline(Calendar updatedStartDate, Calendar updatedEndDate) {
         return updatedStartDate == null && updatedEndDate != null
-                || updatedStartDate != null && updatedEndDate == null;
+               || updatedStartDate != null && updatedEndDate == null;
     }
 
     private static boolean editToFloating(Calendar updatedStartDate, Calendar updatedEndDate) {
@@ -173,7 +184,6 @@ public abstract class EditCommand extends Command {
     /**
      * Stores the details to edit the entry with. Each non-empty field value
      * will replace the corresponding field value of the entry.
-     *
      */
     public static class EditEntryDescriptor {
         private Name name;
@@ -214,7 +224,7 @@ public abstract class EditCommand extends Command {
          */
         public boolean isAnyFieldEdited() {
             return CollectionUtil.isAnyNonNull(this.name, this.tags, this.startDate, this.endDate)
-                    || resetStartDate || resetEndDate;
+                   || resetStartDate || resetEndDate;
         }
 
         public Optional<Calendar> getStartDate() {
@@ -281,7 +291,8 @@ public abstract class EditCommand extends Command {
             EditEntryDescriptor e = (EditEntryDescriptor) other;
             return getName().equals(e.getName()) && getTags().equals(e.getTags())
                    && getStartDate().equals(e.getStartDate()) && getEndDate().equals(e.getEndDate())
-                   && (hasResetStartDate() == e.hasResetStartDate()) && (hasResetEndDate() == e.hasResetEndDate());
+                   && (hasResetStartDate() == e.hasResetStartDate())
+                   && (hasResetEndDate() == e.hasResetEndDate());
         }
     }
 

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -19,7 +19,7 @@ import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 import seedu.multitasky.commons.exceptions.IllegalValueException;
 import seedu.multitasky.logic.commands.AddCommand;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
-import seedu.multitasky.model.UserPrefs;
+import seedu.multitasky.model.LogicUserPrefs;
 import seedu.multitasky.model.entry.Deadline;
 import seedu.multitasky.model.entry.Event;
 import seedu.multitasky.model.entry.FloatingTask;
@@ -39,7 +39,7 @@ public class AddCommandParser {
      * AddCommand and returns an AddCommand object for execution.
      * throws ParseException if the user input does not conform the expected format.
      */
-    public AddCommand parse(String args, UserPrefs userprefs) throws ParseException {
+    public AddCommand parse(String args, LogicUserPrefs userprefs) throws ParseException {
         argMultimap = ArgumentTokenizer.tokenize(args, ParserUtil.toPrefixArray(AddCommand.VALID_PREFIXES));
         Calendar startDate = null;
         Calendar endDate = null;

--- a/src/main/java/seedu/multitasky/logic/parser/Parser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/Parser.java
@@ -22,7 +22,7 @@ import seedu.multitasky.logic.commands.RestoreCommand;
 import seedu.multitasky.logic.commands.SetCommand;
 import seedu.multitasky.logic.commands.UndoCommand;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
-import seedu.multitasky.model.UserPrefs;
+import seedu.multitasky.model.LogicUserPrefs;
 
 /**
  * Parses user input.
@@ -42,7 +42,7 @@ public class Parser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput, UserPrefs userprefs) throws ParseException {
+    public Command parseCommand(String userInput, LogicUserPrefs userprefs) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,

--- a/src/main/java/seedu/multitasky/logic/parser/Parser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/Parser.java
@@ -22,6 +22,7 @@ import seedu.multitasky.logic.commands.RestoreCommand;
 import seedu.multitasky.logic.commands.SetCommand;
 import seedu.multitasky.logic.commands.UndoCommand;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
+import seedu.multitasky.model.UserPrefs;
 
 /**
  * Parses user input.
@@ -41,7 +42,7 @@ public class Parser {
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput, UserPrefs userprefs) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
@@ -53,7 +54,7 @@ public class Parser {
         switch (commandWord.toLowerCase()) {
 
         case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
+            return new AddCommandParser().parse(arguments, userprefs);
 
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);

--- a/src/main/java/seedu/multitasky/model/LogicUserPrefs.java
+++ b/src/main/java/seedu/multitasky/model/LogicUserPrefs.java
@@ -1,0 +1,12 @@
+package seedu.multitasky.model;
+
+// @@author A0140633R
+/**
+ * Represents the default values in UserPrefs object that logic has access to.
+ */
+public interface LogicUserPrefs {
+
+    // returns default hour durations from preferences.json used to extend event entries' date time
+    public int getDurationHour();
+
+}

--- a/src/main/java/seedu/multitasky/model/UserPrefs.java
+++ b/src/main/java/seedu/multitasky/model/UserPrefs.java
@@ -13,10 +13,12 @@ public class UserPrefs {
     private static int index = 0;
     /** Snapshot file path without index and xml */
     private static String entryBookSnapshotPath = "data/snapshots/entrybook";
-    // @@author
     private GuiSettings guiSettings;
     private String entryBookName = "MyEntryBook";
     private String entryBookFilePath = "data/entrybook.xml";
+    // @@author A0140633R
+    private int addDurationHour = 1;
+    // @@author
 
     public UserPrefs() {
         this.setGuiSettings(500, 500, 0, 0);
@@ -66,6 +68,14 @@ public class UserPrefs {
 
     public static int getIndex() {
         return index;
+    }
+
+    public int getDurationHour() {
+        return addDurationHour;
+    }
+
+    public void setDurationHour(int value) {
+        addDurationHour = value;
     }
 
     public static void setIndex(int index) {

--- a/src/main/java/seedu/multitasky/model/UserPrefs.java
+++ b/src/main/java/seedu/multitasky/model/UserPrefs.java
@@ -8,7 +8,7 @@ import seedu.multitasky.commons.core.GuiSettings;
  * Represents User's preferences.
  */
 // @@author A0132788U
-public class UserPrefs {
+public class UserPrefs implements LogicUserPrefs {
     /** Index to maintain snapshot file number */
     private static int index = 0;
     /** Snapshot file path without index and xml */
@@ -17,7 +17,7 @@ public class UserPrefs {
     private String entryBookName = "MyEntryBook";
     private String entryBookFilePath = "data/entrybook.xml";
     // @@author A0140633R
-    private int addDurationHour = 1;
+    private final int defaultDurationHour = 1;
     // @@author
 
     public UserPrefs() {
@@ -70,16 +70,14 @@ public class UserPrefs {
         return index;
     }
 
-    public int getDurationHour() {
-        return addDurationHour;
-    }
-
-    public void setDurationHour(int value) {
-        addDurationHour = value;
-    }
-
     public static void setIndex(int index) {
         UserPrefs.index = index;
+    }
+
+
+    @Override
+    public int getDurationHour() {
+        return defaultDurationHour;
     }
 
     public String getEntryBookName() {

--- a/src/test/java/seedu/multitasky/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/multitasky/logic/LogicManagerTest.java
@@ -87,7 +87,7 @@ public class LogicManagerTest {
     @Before
     public void setUp() {
         model = new ModelManager();
-        logic = new LogicManager(model);
+        logic = new LogicManager(model, new UserPrefs());
         EventsCenter.getInstance().registerHandler(this);
 
         latestSavedEntryBook = new EntryBook(model.getEntryBook()); // last saved assumed to be up to date

--- a/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
@@ -1,7 +1,6 @@
 package seedu.multitasky.logic.parser;
 
 import static org.junit.Assert.assertTrue;
-import static seedu.multitasky.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_AT;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_BY;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FROM;
@@ -15,6 +14,7 @@ import org.junit.rules.ExpectedException;
 import seedu.multitasky.logic.commands.AddCommand;
 import seedu.multitasky.logic.commands.Command;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
+import seedu.multitasky.model.UserPrefs;
 
 
 /**
@@ -29,54 +29,67 @@ public class AddCommandParserTest {
     private static final String VALID_DATE_20JULY = "20 july 2017";
     private static final String INVALID_DATE = "end of time";
 
-
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-
-    private AddCommandParser parser = new AddCommandParser();
+    private final UserPrefs userprefs = new UserPrefs();
+    private final AddCommandParser parser = new AddCommandParser();
 
     //@A0140633R
     @Test
     public void parse_emptyArgs_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
         thrown.expectMessage(String.format(AddCommand.MESSAGE_USAGE));
-        parser.parse("");
+        parser.parse("", userprefs);
     }
 
     @Test
     public void parse_validArgs_returnsAddCommand() throws Exception {
         // floating task
-        Command command = parser.parse(" a typical task name");
+        Command command = parser.parse(" a typical task name", userprefs);
         assertTrue(command instanceof AddCommand);
-        command = parser.parse(" a special task with \\by in its name");
+        command = parser.parse(" a special task with \\by in its name", userprefs);
         assertTrue(command instanceof AddCommand);
 
         // deadline
         command = parser.parse(" a typical task with enddate " + PREFIX_BY
-                               + " " + VALID_DATE_17JULY);
+                               + " " + VALID_DATE_17JULY, userprefs);
         assertTrue(command instanceof AddCommand);
         command = parser.parse(" a special task with enddate and \\by in name "
-                               + PREFIX_BY + " " + VALID_DATE_17JULY);
+                               + PREFIX_BY + " " + VALID_DATE_17JULY, userprefs);
         assertTrue(command instanceof AddCommand);
 
         // event
         command = parser.parse(" a typical task with both start and end date " + PREFIX_FROM + " "
-                               + VALID_DATE_17JULY + " " + PREFIX_TO + " " + VALID_DATE_20JULY);
+                               + VALID_DATE_17JULY + " " + PREFIX_TO + " " + VALID_DATE_20JULY, userprefs);
         assertTrue(command instanceof AddCommand);
         command = parser.parse(" a special task with many start date and end date " + PREFIX_FROM + " "
-                + VALID_DATE_17JULY + " " + PREFIX_AT + " " + VALID_DATE_17JULY + PREFIX_TO + " " + VALID_DATE_20JULY);
+                + VALID_DATE_17JULY + " " + PREFIX_AT + " " + VALID_DATE_17JULY
+                + PREFIX_TO + " " + VALID_DATE_20JULY, userprefs);
         assertTrue(command instanceof AddCommand);
+
+        // start date == end date
+        command = parser.parse("a special full day task " + PREFIX_FROM + " " + VALID_DATE_17JULY
+                               + " " + PREFIX_TO + " " + VALID_DATE_17JULY, userprefs);
+        assertTrue(command instanceof AddCommand);
+
         // only start date variant event
-        command = parser.parse(" a special task with only start date " + PREFIX_FROM + " " + VALID_DATE_17JULY);
+        command = parser.parse(" a special task with only start date " + PREFIX_FROM
+                               + " " + VALID_DATE_17JULY, userprefs);
         assertTrue(command instanceof AddCommand);
-        command = parser.parse(" a special task with only start date " + PREFIX_AT + " " + VALID_DATE_20JULY);
+        command = parser.parse(" a special task with only start date " + PREFIX_AT
+                               + " " + VALID_DATE_20JULY, userprefs);
         assertTrue(command instanceof AddCommand);
+
+        // only end date variant event
+        command = parser.parse("task with only \\to flag " + PREFIX_TO + " " + VALID_DATE_17JULY, userprefs);
+        assertTrue(command instanceof AddCommand);
+
     }
 
     public void parse_invalidArgsFollowedByValidArgs_returnsAddCommand() throws Exception {
         Command command = parser.parse(" a special task with many start date and end date " + PREFIX_FROM + " "
                 + INVALID_DATE + " " + PREFIX_AT + " " + VALID_DATE_17JULY + PREFIX_TO
-                + " " + VALID_DATE_20JULY);
+                + " " + VALID_DATE_20JULY, userprefs);
         assertTrue(command instanceof AddCommand);
     }
 
@@ -84,14 +97,7 @@ public class AddCommandParserTest {
     public void parse_invalidDate_throwsParseException() throws Exception {
         thrown.expect(ParseException.class);
         thrown.expectMessage(String.format(ParserUtil.MESSAGE_FAIL_PARSE_DATE, INVALID_DATE));
-        parser.parse("task with invalid date " + PREFIX_BY + " " + INVALID_DATE);
-    }
-
-    @Test
-    public void parse_invalidFlagCombination_throwsParseException() throws Exception {
-        thrown.expect(ParseException.class);
-        thrown.expectMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
-        parser.parse("task with only \\to flag " + PREFIX_TO + " " + VALID_DATE_17JULY);
+        parser.parse("task with invalid date " + PREFIX_BY + " " + INVALID_DATE, userprefs);
     }
 
     @Test
@@ -99,7 +105,7 @@ public class AddCommandParserTest {
         thrown.expect(ParseException.class);
         thrown.expectMessage(AddCommand.MESSAGE_ENDDATE_BEFORE_STARTDATE);
         parser.parse("task with enddate before startdate " + PREFIX_ON + " " + VALID_DATE_20JULY
-                     + " " + PREFIX_TO + " " + VALID_DATE_17JULY);
+                     + " " + PREFIX_TO + " " + VALID_DATE_17JULY, userprefs);
     }
 
 }

--- a/src/test/java/seedu/multitasky/logic/parser/ParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/ParserTest.java
@@ -12,17 +12,19 @@ import seedu.multitasky.logic.commands.HistoryCommand;
 import seedu.multitasky.logic.commands.RedoCommand;
 import seedu.multitasky.logic.commands.UndoCommand;
 import seedu.multitasky.logic.parser.exceptions.ParseException;
+import seedu.multitasky.model.UserPrefs;
 
 public class ParserTest {
     private final Parser parser = new Parser();
+    private final UserPrefs userprefs = new UserPrefs();
 
     @Test
     public void parseCommand_history() throws Exception {
-        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD) instanceof HistoryCommand);
-        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD + " 3") instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD, userprefs) instanceof HistoryCommand);
+        assertTrue(parser.parseCommand(HistoryCommand.COMMAND_WORD + " 3", userprefs) instanceof HistoryCommand);
 
         try {
-            parser.parseCommand("histories");
+            parser.parseCommand("histories", userprefs);
             fail("The expected ParseException was not thrown.");
         } catch (ParseException pe) {
             assertEquals(MESSAGE_UNKNOWN_COMMAND, pe.getMessage());
@@ -32,16 +34,16 @@ public class ParserTest {
     // @@author A0140633R
     @Test
     public void parseCommand_clear_success() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, userprefs) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_undo_success() throws Exception {
-        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD) instanceof UndoCommand);
+        assertTrue(parser.parseCommand(UndoCommand.COMMAND_WORD, userprefs) instanceof UndoCommand);
     }
 
     @Test
     public void parseCommand_redo_success() throws Exception {
-        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD) instanceof RedoCommand);
+        assertTrue(parser.parseCommand(RedoCommand.COMMAND_WORD, userprefs) instanceof RedoCommand);
     }
 }


### PR DESCRIPTION

Changelog 📜 
- defaultDurationHours now a field in preferences.json for user to change if he wants to. updated default hours to use that field to set dates.
- decided to implement a "`to` only" variant of event. will take addDurationHours and add negative of that to find the start datetime. so now add command will have ***no*** invalid combination of date flags
- implement support for adding full day events. simply add anything with start date and end date time equal, e.g. `add work from tomorrow to tomorrow` adds work from 00:00 to 23:59
- dependency inversion so that higher class LogicManager is free-r of dependencies on model.UserPrefs object

Fixes #171 #169 