### PR TITLE
V0.5rc Clear command can selectively clear entries of specific status

### DIFF
--- a/src/main/java/seedu/multitasky/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/ClearCommand.java
@@ -6,6 +6,7 @@ import seedu.multitasky.logic.parser.CliSyntax;
 import seedu.multitasky.model.EntryBook;
 import seedu.multitasky.model.entry.Entry;
 
+// @@author A0126623L
 /**
  * Clears the entry book.
  */
@@ -45,10 +46,10 @@ public class ClearCommand extends Command {
         clearType = ClearType.ACTIVE;
     }
 
+    // @@author A0126623L
     public ClearCommand(String prefix) {
         /*
-         * TODO: Use hashmap for initialising this.clearType later instead
-         * of multiple if-else
+         * TODO: Consider better ways than using multiple if-else?
          */
         if (prefix.equals(CliSyntax.PREFIX_ALL.toString())) {
             clearType = ClearType.ALL;
@@ -62,7 +63,9 @@ public class ClearCommand extends Command {
             throw new AssertionError("ClearCommand constructor shouldn't reach this point.");
         }
     }
+    // @@author
 
+    // @@author A0126623L
     @Override
     public CommandResult execute() {
         requireNonNull(model);
@@ -84,5 +87,5 @@ public class ClearCommand extends Command {
             throw new AssertionError("Unknown clear command option given.");
         }
     }
-
+    // @@author
 }

--- a/src/main/java/seedu/multitasky/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/ClearCommand.java
@@ -2,7 +2,9 @@ package seedu.multitasky.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.multitasky.logic.parser.CliSyntax;
 import seedu.multitasky.model.EntryBook;
+import seedu.multitasky.model.entry.Entry;
 
 /**
  * Clears the entry book.
@@ -10,16 +12,77 @@ import seedu.multitasky.model.EntryBook;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Entry book has been cleared!";
 
-    public static final String[] VALID_PREFIXES = {};
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Clear entries in the entry book. " + "\n"
+                                               + "Format: " + COMMAND_WORD
+                                               + " [" + CliSyntax.PREFIX_ARCHIVE + " | "
+                                               + CliSyntax.PREFIX_BIN + " | "
+                                               + CliSyntax.PREFIX_ALL + "]" + "\n"
+                                               + "Example: " + COMMAND_WORD + " " + CliSyntax.PREFIX_BIN;
+
+    public static final String MESSAGE_ALL_SUCCESS = "Entry book has been cleared!";
+
+    public static final String MESSAGE_ACTIVE_SUCCESS = "Active entries have been cleared!";
+
+    public static final String MESSAGE_ARCHIVE_SUCCESS = "Archive has been cleared!";
+
+    public static final String MESSAGE_BIN_SUCCESS = "Bin has been cleared!";
+
+    public static final int NUMBER_ALLOWABLE_PREFIX = 1;
+
+    public static final String[] VALID_PREFIXES = { CliSyntax.PREFIX_ACTIVE.toString(),
+        CliSyntax.PREFIX_ARCHIVE.toString(),
+        CliSyntax.PREFIX_BIN.toString(),
+        CliSyntax.PREFIX_ALL.toString() };
+
+    public enum ClearType {
+        ACTIVE, ARCHIVE, BIN, ALL
+    }
+
+    private ClearType clearType;
+
+    public ClearCommand() {
+        clearType = ClearType.ACTIVE;
+    }
+
+    public ClearCommand(String prefix) {
+        /*
+         * TODO: Use hashmap for initialising this.clearType later instead
+         * of multiple if-else
+         */
+        if (prefix.equals(CliSyntax.PREFIX_ALL.toString())) {
+            clearType = ClearType.ALL;
+        } else if (prefix.equals(CliSyntax.PREFIX_ARCHIVE.toString())) {
+            clearType = ClearType.ARCHIVE;
+        } else if (prefix.equals(CliSyntax.PREFIX_BIN.toString())) {
+            clearType = ClearType.BIN;
+        } else if (prefix.equals(CliSyntax.PREFIX_ACTIVE.toString())) {
+            clearType = ClearType.ACTIVE;
+        } else {
+            throw new AssertionError("ClearCommand constructor shouldn't reach this point.");
+        }
+    }
 
     @Override
     public CommandResult execute() {
         requireNonNull(model);
 
-        model.resetData(new EntryBook());
-        return new CommandResult(MESSAGE_SUCCESS);
+        switch (clearType) {
+        case ALL:
+            model.resetData(new EntryBook());
+            return new CommandResult(MESSAGE_ALL_SUCCESS);
+        case ACTIVE:
+            model.clearStateSpecificEntries(Entry.State.ACTIVE);
+            return new CommandResult(MESSAGE_ACTIVE_SUCCESS);
+        case ARCHIVE:
+            model.clearStateSpecificEntries(Entry.State.ARCHIVED);
+            return new CommandResult(MESSAGE_ARCHIVE_SUCCESS);
+        case BIN:
+            model.clearStateSpecificEntries(Entry.State.DELETED);
+            return new CommandResult(MESSAGE_BIN_SUCCESS);
+        default:
+            throw new AssertionError("Unknown clear command option given.");
+        }
     }
 
 }

--- a/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
@@ -12,8 +12,6 @@ import seedu.multitasky.logic.parser.exceptions.ParseException;
  */
 public class ClearCommandParser {
 
-    private ArgumentMultimap argumentMultimap;
-
     // @@author A0126623L
     /** Parses the given arguments in the context of a clear command.
      *
@@ -22,6 +20,7 @@ public class ClearCommandParser {
      * @throws ParseException if the user input does not conform to the expected format
      */
     public ClearCommand parse(String args) throws ParseException {
+
         String trimmedArgs = args.trim();
 
         if (trimmedArgs.isEmpty()) {
@@ -32,8 +31,8 @@ public class ClearCommandParser {
          * TODO modify ArgumentTokenizer to be able to detect without needing a whitespace in front of
          * trimmedArgs
          */
-        argumentMultimap = ArgumentTokenizer.tokenize(" " + trimmedArgs,
-                                                      toPrefixArray(ClearCommand.VALID_PREFIXES));
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(" " + trimmedArgs,
+                                                                       toPrefixArray(ClearCommand.VALID_PREFIXES));
 
         ArrayList<String> prefixesPresent = argumentMultimap.getPresentPrefixes(ClearCommand.VALID_PREFIXES);
         if (!hasValidPrefixNumber(prefixesPresent)) {

--- a/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.multitasky.logic.parser;
+
+import java.util.ArrayList;
+
+import seedu.multitasky.commons.core.Messages;
+import seedu.multitasky.logic.commands.ClearCommand;
+import seedu.multitasky.logic.parser.exceptions.ParseException;
+
+//@@author A0126623L
+/**
+ * Parses input arguments and creates an appropriate ClearCommand object.
+ */
+public class ClearCommandParser {
+
+    private ArgumentMultimap argumentMultimap;
+
+    // @@author A0126623L
+    /** Parses the given arguments in the context of a clear command.
+     *
+     * @param args the arguments for the clear command in a single String
+     * @return     the ClearCommand object for execution
+     * @throws ParseException if the user input does not conform to the expected format
+     */
+    public ClearCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+
+        if (trimmedArgs.isEmpty()) {
+            return new ClearCommand();
+        }
+
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize("preamble " + trimmedArgs,
+                                                                       toPrefixArray(ClearCommand.VALID_PREFIXES));
+
+        // argumentMultimap = ArgumentTokenizer.tokenize(trimmedArgs,
+        // toPrefixArray(ClearCommand.VALID_PREFIXES));
+
+        ArrayList<String> prefixesPresent = argumentMultimap.getPresentPrefixes(ClearCommand.VALID_PREFIXES);
+        if (!hasValidPrefixNumber(prefixesPresent)) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                                                   ClearCommand.MESSAGE_USAGE));
+        }
+
+        return new ClearCommand(prefixesPresent.get(0));
+    }
+    // @@author
+
+    // @@author A0126623L
+    private boolean hasValidPrefixNumber(ArrayList<String> prefixes) {
+        return (prefixes.size() == ClearCommand.NUMBER_ALLOWABLE_PREFIX);
+    }
+    // @@author
+
+    // @@author A0126623L-reused
+    private Prefix[] toPrefixArray(String... stringPrefixes) {
+        Prefix[] prefixes = new Prefix[stringPrefixes.length];
+        for (int i = 0; i < stringPrefixes.length; ++i) {
+            prefixes[i] = new Prefix(stringPrefixes[i]);
+        }
+        return prefixes;
+    }
+
+}

--- a/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
@@ -28,11 +28,12 @@ public class ClearCommandParser {
             return new ClearCommand();
         }
 
-        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize("preamble " + trimmedArgs,
-                                                                       toPrefixArray(ClearCommand.VALID_PREFIXES));
-
-        // argumentMultimap = ArgumentTokenizer.tokenize(trimmedArgs,
-        // toPrefixArray(ClearCommand.VALID_PREFIXES));
+        /*
+         * TODO modify ArgumentTokenizer to be able to detect without needing a whitespace in front of
+         * trimmedArgs
+         */
+        argumentMultimap = ArgumentTokenizer.tokenize(" " + trimmedArgs,
+                                                      toPrefixArray(ClearCommand.VALID_PREFIXES));
 
         ArrayList<String> prefixesPresent = argumentMultimap.getPresentPrefixes(ClearCommand.VALID_PREFIXES);
         if (!hasValidPrefixNumber(prefixesPresent)) {

--- a/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ClearCommandParser.java
@@ -58,5 +58,6 @@ public class ClearCommandParser {
         }
         return prefixes;
     }
+    // @@author
 
 }

--- a/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/multitasky/logic/parser/CliSyntax.java
@@ -25,6 +25,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_FLOATINGTASK = new Prefix("float");
 
     /* EntryLists */
+    public static final Prefix PREFIX_ACTIVE = new Prefix("active");
     public static final Prefix PREFIX_ARCHIVE = new Prefix("archive");
     public static final Prefix PREFIX_BIN = new Prefix("bin");
     public static final Prefix PREFIX_ALL = new Prefix("all");

--- a/src/main/java/seedu/multitasky/logic/parser/Parser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/Parser.java
@@ -45,7 +45,7 @@ public class Parser {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    HelpCommand.MESSAGE_USAGE));
+                                                   HelpCommand.MESSAGE_USAGE));
         }
 
         final String commandWord = matcher.group("commandWord");
@@ -65,7 +65,7 @@ public class Parser {
             return new CompleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
-            return new ClearCommand();
+            return new ClearCommandParser().parse(arguments);
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);

--- a/src/main/java/seedu/multitasky/logic/parser/RestoreCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/RestoreCommandParser.java
@@ -36,10 +36,12 @@ public class RestoreCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public RestoreCommand parse(String args) throws ParseException {
-        argMultimap = ArgumentTokenizer.tokenize(args, ParserUtil.toPrefixArray(RestoreCommand.VALID_PREFIXES));
+        argMultimap = ArgumentTokenizer.tokenize(args,
+                                                 ParserUtil.toPrefixArray(RestoreCommand.VALID_PREFIXES));
 
         if (args.trim().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RestoreCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                                                   RestoreCommand.MESSAGE_USAGE));
         }
 
         if (hasIndexFlag(argMultimap)) { // process to restore by indexes
@@ -68,16 +70,19 @@ public class RestoreCommandParser {
     }
     // @@author
 
+    /**
+     * TODO: Since more than 1 command parsers (delete, complete and restore) use the method below,
+     * it may be refactored into the ParserUtil class as a static method.
+     */
     // @@author A0126623L-reused
     /**
      * A method that returns true if flags are given in an illogical manner for restoring commands.
      * illogical := any 2 of /float, /deadline, /event used together.
-     *
-     * TODO: Since more than 1 command parsers (delete, complete and restore) use this method,
-     * it may be refactored into the ParserUtil class as a static method.
      */
     private boolean hasInvalidFlagCombination(ArgumentMultimap argMultimap) {
-        assert argMultimap != null;
+        if (argMultimap == null) {
+            throw new AssertionError("argMultimap cannot be null.");
+        }
         return ParserUtil.areAllPrefixesPresent(argMultimap, PREFIX_FLOATINGTASK, PREFIX_DEADLINE)
                || ParserUtil.areAllPrefixesPresent(argMultimap, PREFIX_DEADLINE, PREFIX_EVENT)
                || ParserUtil.areAllPrefixesPresent(argMultimap, PREFIX_FLOATINGTASK, PREFIX_EVENT);

--- a/src/main/java/seedu/multitasky/model/Model.java
+++ b/src/main/java/seedu/multitasky/model/Model.java
@@ -31,6 +31,9 @@ public interface Model {
     /** Deletes the given entry. */
     void deleteEntry(ReadOnlyEntry target) throws DuplicateEntryException, EntryNotFoundException;
 
+    /** Clears all entries of a specific state. */
+    public void clearStateSpecificEntries(Entry.State state);
+
     /** Adds the given entry */
     void addEntry(ReadOnlyEntry entry) throws DuplicateEntryException, OverlappingEventException;
 
@@ -95,21 +98,21 @@ public interface Model {
     void updateAllFilteredLists(Set<String> keywords, Calendar startDate, Calendar endDate,
                                 Entry.State state);
 
-    /*
+    /**
      * Updates the filter of the filtered event list to filter by the given keywords,
      * date range and state using the specified search type.
      */
     void updateFilteredEventList(Set<String> keywords, Calendar startDate, Calendar endDate,
                                  Entry.State state, Search search);
 
-    /*
+    /**
      * Updates the filter of the filtered deadline list to filter by the given keywords,
      * date range and state using the specified search type.
      */
     void updateFilteredDeadlineList(Set<String> keywords, Calendar startDate, Calendar endDate,
                                     Entry.State state, Search search);
 
-    /*
+    /**
      * Updates the filter of the filtered floating task list to filter by the given keywords,
      * date range and state using the specified search type.
      */

--- a/src/main/java/seedu/multitasky/model/ModelManager.java
+++ b/src/main/java/seedu/multitasky/model/ModelManager.java
@@ -77,50 +77,17 @@ public class ModelManager extends ComponentManager implements Model {
         return _entryBook;
     }
 
-    /** Raises an event to indicate the model has changed */
-    private void indicateEntryBookChanged() {
-        raise(new EntryBookChangedEvent(_entryBook));
-    }
+    // =========== List Level Operations ===========
 
-    // @@author A0132788U
-    /** Raises an event when undo is entered by user and resets data to previous state for updating the UI */
-    private void indicateUndoAction() throws NothingToUndoException {
-        EntryBookToUndoEvent undoEvent;
-        raise(undoEvent = new EntryBookToUndoEvent(_entryBook, ""));
-        if (undoEvent.getMessage().equals("undo successful")) {
-            _entryBook.resetData(undoEvent.getData());
-        } else {
-            throw new NothingToUndoException("");
-        }
-    }
-
-    /** Raises an event when redo is entered by user and resets data to next state for updating the UI */
-    private void indicateRedoAction() throws NothingToRedoException {
-        EntryBookToRedoEvent redoEvent;
-        raise(redoEvent = new EntryBookToRedoEvent(_entryBook, ""));
-        if (redoEvent.getMessage().equals("redo successful")) {
-            _entryBook.resetData(redoEvent.getData());
-        } else {
-            throw new NothingToRedoException("");
-        }
-    }
-
+    // @@author A0126623L
     @Override
-    public void undoPreviousAction() throws NothingToUndoException {
-        indicateUndoAction();
-    }
-
-    @Override
-    public void redoPreviousAction() throws NothingToRedoException {
-        indicateRedoAction();
-    }
-
-    /** Raises an event when new file path is entered by user */
-    @Override
-    public void changeFilePath(String newFilePath) {
-        raise(new FilePathChangedEvent(_entryBook, newFilePath));
+    public void clearStateSpecificEntries(Entry.State state) {
+        _entryBook.clearStateSpecificEntries(state);
+        indicateEntryBookChanged();
     }
     // @@author
+
+    // =========== Entry Level Operations ===========
 
     @Override
     public synchronized void deleteEntry(ReadOnlyEntry target)
@@ -206,7 +173,7 @@ public class ModelManager extends ComponentManager implements Model {
     // @@author A0126623L
     @Override
     public UnmodifiableObservableList<ReadOnlyEntry> getActiveList() {
-        return new UnmodifiableObservableList<>(_entryBook.getActiveList());
+        return new UnmodifiableObservableList<>(_entryBook.getAllEntries());
     }
 
     // @@author A0126623L
@@ -563,5 +530,52 @@ public class ModelManager extends ComponentManager implements Model {
             return builder.toString();
         }
     }
+
+    // ========== Event Raising Methods ==========
+
+    /** Raises an event to indicate the model has changed */
+    private void indicateEntryBookChanged() {
+        raise(new EntryBookChangedEvent(_entryBook));
+    }
+
+    // @@author A0132788U
+    /** Raises an event when undo is entered by user and resets data to previous state for updating the UI */
+    private void indicateUndoAction() throws NothingToUndoException {
+        EntryBookToUndoEvent undoEvent;
+        raise(undoEvent = new EntryBookToUndoEvent(_entryBook, ""));
+        if (undoEvent.getMessage().equals("undo successful")) {
+            _entryBook.resetData(undoEvent.getData());
+        } else {
+            throw new NothingToUndoException("");
+        }
+    }
+
+    /** Raises an event when redo is entered by user and resets data to next state for updating the UI */
+    private void indicateRedoAction() throws NothingToRedoException {
+        EntryBookToRedoEvent redoEvent;
+        raise(redoEvent = new EntryBookToRedoEvent(_entryBook, ""));
+        if (redoEvent.getMessage().equals("redo successful")) {
+            _entryBook.resetData(redoEvent.getData());
+        } else {
+            throw new NothingToRedoException("");
+        }
+    }
+
+    @Override
+    public void undoPreviousAction() throws NothingToUndoException {
+        indicateUndoAction();
+    }
+
+    @Override
+    public void redoPreviousAction() throws NothingToRedoException {
+        indicateRedoAction();
+    }
+
+    /** Raises an event when new file path is entered by user */
+    @Override
+    public void changeFilePath(String newFilePath) {
+        raise(new FilePathChangedEvent(_entryBook, newFilePath));
+    }
+    // @@author
 
 }

--- a/src/main/java/seedu/multitasky/model/ReadOnlyEntryBook.java
+++ b/src/main/java/seedu/multitasky/model/ReadOnlyEntryBook.java
@@ -13,7 +13,7 @@ public interface ReadOnlyEntryBook {
      * Returns an unmodifiable view of the active entry list.
      * TODO: Update this Javadoc if duplicate is not allowed in the future.
      */
-    ObservableList<ReadOnlyEntry> getActiveList();
+    ObservableList<ReadOnlyEntry> getAllEntries();
 
     /**
      * Returns an unmodifiable view of the (active) event list.

--- a/src/main/java/seedu/multitasky/storage/XmlSerializableEntryBook.java
+++ b/src/main/java/seedu/multitasky/storage/XmlSerializableEntryBook.java
@@ -107,7 +107,7 @@ public class XmlSerializableEntryBook implements ReadOnlyEntryBook {
     }
 
     @Override
-    public ObservableList<ReadOnlyEntry> getActiveList() {
+    public ObservableList<ReadOnlyEntry> getAllEntries() {
         final ObservableList<Entry> active = this.active.stream().map(p -> {
             try {
                 return p.toModelType();

--- a/src/test/java/guitests/ClearCommandTest.java
+++ b/src/test/java/guitests/ClearCommandTest.java
@@ -16,31 +16,31 @@ public class ClearCommandTest extends EntryBookGuiTest {
      * Clearing the list *
      ********************/
     @Test
-    public void clear_emptyList_success() {
-        assertClearCommandSuccess();
-        assertClearCommandSuccess();
+    public void clearAll_emptyList_success() {
+        assertClearAllCommandSuccess();
+        assertClearAllCommandSuccess();
     }
 
     /**********************************
      * Adding after clearing the list *
      *********************************/
     @Test
-    public void clear_addEventAfterClear_success() {
-        assertClearCommandSuccess();
+    public void clear_addEventAfterClearAll_success() {
+        assertClearAllCommandSuccess();
         commandBox.runCommand(CommandUtil.getAddEventCommand(SampleEntries.CAT));
         assertTrue(eventListPanel.isListMatching(SampleEntries.CAT));
     }
 
     @Test
-    public void clear_addDeadlineAfterClear_success() {
-        assertClearCommandSuccess();
+    public void clear_addDeadlineAfterClearAll_success() {
+        assertClearAllCommandSuccess();
         commandBox.runCommand(CommandUtil.getAddDeadlineCommand(SampleEntries.SUBMISSION));
         assertTrue(deadlineListPanel.isListMatching(SampleEntries.SUBMISSION));
     }
 
     @Test
-    public void clear_addFloatingTaskAfterClear_success() {
-        assertClearCommandSuccess();
+    public void clear_addFloatingTaskAfterClearAll_success() {
+        assertClearAllCommandSuccess();
         commandBox.runCommand(CommandUtil.getAddFloatingTaskCommand(SampleEntries.CLEAN));
         assertTrue(floatingTaskListPanel.isListMatching(SampleEntries.CLEAN));
     }
@@ -121,8 +121,8 @@ public class ClearCommandTest extends EntryBookGuiTest {
         assertTrue(floatingTaskListPanel.isEmpty());
     }
 
-    private void assertClearCommandSuccess() {
-        commandBox.runCommand(ClearCommand.COMMAND_WORD);
+    private void assertClearAllCommandSuccess() {
+        commandBox.runCommand(ClearCommand.COMMAND_WORD + " all");
         assertCleared();
         assertResultMessage("Entry book has been cleared!");
     }

--- a/src/test/java/seedu/multitasky/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/AddCommandTest.java
@@ -219,6 +219,11 @@ public class AddCommandTest {
             fail("This method should not be called.");
         }
 
+        @Override
+        public void clearStateSpecificEntries(State state) {
+            fail("This method should not be called.");
+        }
+
     }
 
     /**

--- a/src/test/java/seedu/multitasky/logic/commands/ClearCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/ClearCommandTest.java
@@ -26,15 +26,15 @@ public class ClearCommandTest {
 
     /**
      * Executes {@code ClearCommand} on the given {@code model}, confirms that <br>
-     * - the result message matches {@code ClearCommand.MESSAGE_SUCCESS} <br>
+     * - the result message matches {@code ClearCommand.MESSAGE_ACTIVE_SUCCESS} <br>
      * - the address book and filtered entry list in {@code model} is empty <br>
      */
     private void assertCommandSuccess(Model model) {
-        ClearCommand command = new ClearCommand();
+        ClearCommand command = new ClearCommand("all");
         command.setData(model, new CommandHistory());
         CommandResult result = command.execute();
 
-        assertEquals(ClearCommand.MESSAGE_SUCCESS, result.feedbackToUser);
+        assertEquals(ClearCommand.MESSAGE_ALL_SUCCESS, result.feedbackToUser);
         assertEquals(new ModelManager(), model);
     }
 }

--- a/src/test/java/seedu/multitasky/model/EntryBookTest.java
+++ b/src/test/java/seedu/multitasky/model/EntryBookTest.java
@@ -104,18 +104,18 @@ public class EntryBookTest {
             EntryBook entryBookUnderTest = EntryBookTest.getSampleEntryBook();
 
             Entry eventToRemove = listOfEventLists[0].asObservableList().get(0);
-            assertTrue(entryBookUnderTest.getActiveList().contains(eventToRemove));
+            assertTrue(entryBookUnderTest.getAllEntries().contains(eventToRemove));
             Entry deadlineToRemove = listOfDeadlineLists[0].asObservableList().get(0);
-            assertTrue(entryBookUnderTest.getActiveList().contains(deadlineToRemove));
+            assertTrue(entryBookUnderTest.getAllEntries().contains(deadlineToRemove));
             Entry floatingTaskToRemove = listOfFloatingTaskLists[0].asObservableList().get(0);
-            assertTrue(entryBookUnderTest.getActiveList().contains(floatingTaskToRemove));
+            assertTrue(entryBookUnderTest.getAllEntries().contains(floatingTaskToRemove));
 
             entryBookUnderTest.removeEntry(eventToRemove);
-            assertFalse(entryBookUnderTest.getActiveList().contains(eventToRemove));
+            assertFalse(entryBookUnderTest.getAllEntries().contains(eventToRemove));
             entryBookUnderTest.removeEntry(deadlineToRemove);
-            assertFalse(entryBookUnderTest.getActiveList().contains(deadlineToRemove));
+            assertFalse(entryBookUnderTest.getAllEntries().contains(deadlineToRemove));
             entryBookUnderTest.removeEntry(floatingTaskToRemove);
-            assertFalse(entryBookUnderTest.getActiveList().contains(floatingTaskToRemove));
+            assertFalse(entryBookUnderTest.getAllEntries().contains(floatingTaskToRemove));
 
             try {
                 entryBookUnderTest.removeEntry(eventToRemove);


### PR DESCRIPTION
@CS2103JUN2017-T2/developers 
Note that future tests that want to clear all entries will need to do `clear all` now, instead of just `clear` (default to clearing active entries). I've already made the necessary changes to existing tests.

Part of #193 