### PR TITLE
V0.5 dateparsing

### DIFF
--- a/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/multitasky/logic/commands/EditCommand.java
@@ -150,9 +150,9 @@ public abstract class EditCommand extends Command {
         } else if (editToEvent(updatedStartDate, updatedEndDate) // event with start date == end date
                    && updatedEndDate.compareTo(updatedStartDate) == 0) {
             // convert automatically to full day event
-            updatedStartDate.set(Calendar.HOUR, 0);
+            updatedStartDate.set(Calendar.HOUR_OF_DAY, 0);
             updatedStartDate.set(Calendar.MINUTE, 0);
-            updatedEndDate.set(Calendar.HOUR, 23);
+            updatedEndDate.set(Calendar.HOUR_OF_DAY, 23);
             updatedEndDate.set(Calendar.MINUTE, 59);
             return new Event(updatedName, updatedStartDate, updatedEndDate, updatedTags);
 

--- a/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/AddCommandParser.java
@@ -100,8 +100,9 @@ public class AddCommandParser {
                 Prefix startDatePrefix = requireNonNull(ParserUtil.getLastPrefix(
                         args, PREFIX_FROM, PREFIX_ON, PREFIX_AT));
                 Prefix endDatePrefix = requireNonNull(ParserUtil.getLastPrefix(args, PREFIX_TO, PREFIX_BY));
-                endDate = ParserUtil.parseDate(argMultimap.getValue(endDatePrefix).get());
                 startDate = ParserUtil.parseDate(argMultimap.getValue(startDatePrefix).get());
+                endDate = ParserUtil.parseExtendedDate(argMultimap.getValue(startDatePrefix).get(),
+                                                       argMultimap.getValue(endDatePrefix).get());
 
                 // check for special cases of date
                 endDate.set(Calendar.SECOND, 0);
@@ -112,9 +113,9 @@ public class AddCommandParser {
                     throw new ParseException(AddCommand.MESSAGE_ENDDATE_BEFORE_STARTDATE);
                 } else if (endDate.compareTo(startDate) == 0) {
                     // convert automatically to full day event
-                    startDate.set(Calendar.HOUR, 0);
+                    startDate.set(Calendar.HOUR_OF_DAY, 0);
                     startDate.set(Calendar.MINUTE, 0);
-                    endDate.set(Calendar.HOUR, 23);
+                    endDate.set(Calendar.HOUR_OF_DAY, 23);
                     endDate.set(Calendar.MINUTE, 59);
                     ReadOnlyEntry entry = new Event(name, startDate, endDate, tagList);
 

--- a/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/multitasky/logic/parser/EditCommandParser.java
@@ -117,14 +117,16 @@ public class EditCommandParser {
                 ParserUtil.parseDate(argMultimap.getValue(startDatePrefix))
                           .ifPresent(editEntryDescriptor::setStartDate);
             }
-            if (endDatePrefix != null) {
+            if (startDatePrefix != null && endDatePrefix != null) {
+                ParserUtil.parseExtendedDate(argMultimap.getValue(startDatePrefix),
+                                             argMultimap.getValue(endDatePrefix))
+                          .ifPresent(editEntryDescriptor::setEndDate);
+            } else if (startDatePrefix == null && endDatePrefix != null) {
                 ParserUtil.parseDate(argMultimap.getValue(endDatePrefix))
                           .ifPresent(editEntryDescriptor::setEndDate);
             }
-            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG))
-                      .ifPresent(editEntryDescriptor::setTags);
-            parseTagsForEdit(argMultimap.getAllValues(PREFIX_ADDTAG))
-                      .ifPresent(editEntryDescriptor::setAddTags);
+            parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editEntryDescriptor::setTags);
+            parseTagsForEdit(argMultimap.getAllValues(PREFIX_ADDTAG)).ifPresent(editEntryDescriptor::setAddTags);
         } catch (IllegalValueException ive) {
             throw new ParseException(ive.getMessage(), ive);
         }

--- a/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/multitasky/logic/parser/ParserUtil.java
@@ -67,10 +67,9 @@ public class ParserUtil {
     /**
      * Parses a {@code Optional<String> name} into an {@code Optional<Calendar>} if {@code name} is present.
      */
-
     public static Optional<Calendar> parseDate(Optional<String> inputArgs) throws IllegalValueException {
         requireNonNull(inputArgs);
-        return inputArgs.isPresent() ? Optional.of(parseDate(inputArgs.get())) // overload old method
+        return inputArgs.isPresent() ? Optional.of(parseDate(inputArgs.get()))
                                      : Optional.empty();
     }
 
@@ -82,18 +81,50 @@ public class ParserUtil {
     public static Calendar parseDate(String args) throws ParseException {
         PrettyTimeParser ptp = new PrettyTimeParser();
         Calendar calendar = new GregorianCalendar();
-        try {
-            List<Date> dates = ptp.parse(args);
-            if (dates.size() != 1) {
-                throw new ParseException(String.format(MESSAGE_FAIL_PARSE_DATE, args));
-            }
-            Date date = dates.get(0);
-            calendar.setTime(date);
-            return calendar;
-        } catch (Exception e) {
-            // double exception catching as a fail-safe
+
+        List<Date> dates = ptp.parse(args);
+        if (dates.size() != 1) {
             throw new ParseException(String.format(MESSAGE_FAIL_PARSE_DATE, args));
         }
+        Date date = dates.get(0);
+        calendar.setTime(date);
+        return calendar;
+
+    }
+
+    /**
+     * Parses a {@code Optional<String> name} into an {@code Optional<Calendar>} if both {@code firstArgs}
+     * & {@code secondArgs} is present.
+     */
+    public static Optional<Calendar> parseExtendedDate(Optional<String> firstArgs,
+            Optional<String> secondArgs) throws IllegalValueException {
+        return firstArgs.isPresent() && secondArgs.isPresent()
+                ? Optional.of(parseExtendedDate(firstArgs.get(), secondArgs.get())) : Optional.empty();
+    }
+
+    /**
+     * converts second arguments into Calendar using required missing Date fields (such as month) taken from the
+     * first date parameters.
+     * first date arguments should be valid
+     * @throws IllegalValueException if either input args String cannot be parsed into a Date.
+     */
+    public static Calendar parseExtendedDate(String firstDateArgs, String secondDateArgs) throws ParseException {
+        String combinedDateArgs = firstDateArgs.trim() + " to " + secondDateArgs.trim();
+        PrettyTimeParser ptp = new PrettyTimeParser();
+        Calendar calendar = new GregorianCalendar();
+
+        List<Date> dates = ptp.parse(firstDateArgs);
+        if (dates.size() != 1) {
+            throw new ParseException(String.format(MESSAGE_FAIL_PARSE_DATE, firstDateArgs));
+        }
+        dates = ptp.parse(combinedDateArgs);
+        if (dates.size() != 2) {
+            throw new ParseException(String.format(MESSAGE_FAIL_PARSE_DATE, secondDateArgs));
+        }
+        Date secondDate = dates.get(1);
+        calendar.setTime(secondDate);
+        return calendar;
+
     }
     // @@author
 

--- a/src/test/java/seedu/multitasky/logic/CommandHistoryTest.java
+++ b/src/test/java/seedu/multitasky/logic/CommandHistoryTest.java
@@ -25,16 +25,7 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void init_success() {
-        Calendar expectedStartDate = null;
-        Calendar expectedEndDate = null;
-        Set<String> expectedKeywords = new HashSet<String>();
-        Entry.State expectedState = Entry.State.ACTIVE;
-        assertAll(history, expectedKeywords, expectedStartDate, expectedEndDate, expectedState);
-    }
-
-    @Test
-    public void commandHistory_add_success() {
+    public void add_anyCommand_success() {
         final String validCommand = "clear";
         final String invalidCommand = "adds Task";
 
@@ -50,7 +41,11 @@ public class CommandHistoryTest {
         Set<String> keywords = new HashSet<String>(Arrays.asList("new keywords"));
         Entry.State state = Entry.State.ARCHIVED;
         history.setPrevSearch(keywords, startDate, endDate, state);
-        assertAll(history, keywords, startDate, endDate, state);
+
+        assertEquals(history.getPrevKeywords(), keywords);
+        assertEquals(history.getPrevStartDate(), startDate);
+        assertEquals(history.getPrevEndDate(), endDate);
+        assertEquals(history.getPrevState(), state);
     }
 
     @Test
@@ -61,14 +56,6 @@ public class CommandHistoryTest {
         history.setEditHistory(editEntryDescriptor);
         assertTrue(history.hasEditHistory());
         assertEquals(history.getEditHistory(), editEntryDescriptor);
-    }
-
-    private void assertAll(CommandHistory history, Set<String> expectedKeywords, Calendar expectedStartDate,
-                           Calendar expectedEndDate, Entry.State expectedState) {
-        assertEquals(history.getPrevKeywords(), expectedKeywords);
-        assertEquals(history.getPrevStartDate(), expectedStartDate);
-        assertEquals(history.getPrevEndDate(), expectedEndDate);
-        assertEquals(history.getPrevState(), expectedState);
     }
 
 }

--- a/src/test/java/seedu/multitasky/logic/commands/DeleteByFindCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/DeleteByFindCommandTest.java
@@ -54,7 +54,7 @@ public class DeleteByFindCommandTest {
     }
 
     @Test
-    public void execute_noEntryFoundUnfilteredList_returnsNoEntriesMessage() throws Exception {
+    public void execute_noEntryFoundUnfilteredList_throwsCommandException() throws Exception {
         thrown.expect(CommandException.class);
         thrown.expectMessage(DeleteByFindCommand.MESSAGE_NO_ENTRIES);
 
@@ -66,7 +66,7 @@ public class DeleteByFindCommandTest {
     }
 
     @Test
-    public void execute_multipleEntriesFoundFilteredList_returnsMultipleEntriesMessage() throws Exception {
+    public void execute_multipleEntriesFoundFilteredList_throwsCommandException() throws Exception {
         thrown.expect(CommandException.class);
         thrown.expectMessage(DeleteByFindCommand.MESSAGE_MULTIPLE_ENTRIES);
 
@@ -88,7 +88,7 @@ public class DeleteByFindCommandTest {
         ReadOnlyEntry entryToDelete = model.getFilteredFloatingTaskList()
                                            .get(INDEX_FIRST_ENTRY.getZeroBased());
 
-        String searchString = entryToDelete.getName().fullName.replaceAll("\\\\", "");
+        String searchString = entryToDelete.getName().fullName;
         HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
 
         DeleteCommand deleteCommand = prepareCommand(model, keywords);

--- a/src/test/java/seedu/multitasky/logic/commands/EditByFindCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditByFindCommandTest.java
@@ -3,7 +3,6 @@ package seedu.multitasky.logic.commands;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 import static seedu.multitasky.logic.parser.CliSyntax.PREFIX_FLOATINGTASK;
 import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_CLEAN;
 import static seedu.multitasky.testutil.EditCommandTestUtil.DESC_MEETING;
@@ -18,22 +17,18 @@ import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_SECOND_ENTRY;
 
 import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Date;
-import java.util.GregorianCalendar;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
 
 import seedu.multitasky.commons.util.PowerMatch;
 import seedu.multitasky.logic.CommandHistory;
 import seedu.multitasky.logic.commands.EditCommand.EditEntryDescriptor;
 import seedu.multitasky.logic.commands.exceptions.CommandException;
+import seedu.multitasky.logic.parser.ParserUtil;
 import seedu.multitasky.model.EntryBook;
 import seedu.multitasky.model.Model;
 import seedu.multitasky.model.ModelManager;
@@ -62,8 +57,8 @@ public class EditByFindCommandTest {
         ReadOnlyEntry targetEntry = model.getFilteredEventList().get(0);
         String searchString = targetEntry.getName().fullName;
         HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
-        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_12_JULY_17),
-                parseDate(VALID_DATE_20_DEC_17), VALID_TAG_URGENT, VALID_TAG_FRIEND);
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, ParserUtil.parseDate(VALID_DATE_12_JULY_17),
+                ParserUtil.parseDate(VALID_DATE_20_DEC_17), VALID_TAG_URGENT, VALID_TAG_FRIEND);
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
                 .withName(VALID_NAME_CLEAN).withStartDate(VALID_DATE_12_JULY_17).withEndDate(VALID_DATE_20_DEC_17)
                 .withTags(VALID_TAG_URGENT, VALID_TAG_FRIEND).build();
@@ -73,7 +68,7 @@ public class EditByFindCommandTest {
         Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
         try {
             expectedModel.updateEntry(expectedModel.getFilteredEventList().get(INDEX_FIRST_ENTRY.getZeroBased()),
-                                  editedEntry);
+                                      editedEntry);
         } catch (EntryOverdueException eoe) {
             // Do nothing. Accept overdue entries in test.
         }
@@ -90,7 +85,7 @@ public class EditByFindCommandTest {
         ReadOnlyEntry targetEntry = model.getFilteredDeadlineList().get(0);
         String searchString = targetEntry.getName().fullName;
         HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
-        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, parseDate(VALID_DATE_11_JULY_17),
+        Entry editedEntry = EntryBuilder.build(VALID_NAME_CLEAN, ParserUtil.parseDate(VALID_DATE_11_JULY_17),
                                                VALID_TAG_URGENT, VALID_TAG_FRIEND);
         EditEntryDescriptor descriptor = new EditEntryDescriptorBuilder(editedEntry)
                 .withName(VALID_NAME_CLEAN).withEndDate(VALID_DATE_11_JULY_17)
@@ -101,7 +96,7 @@ public class EditByFindCommandTest {
         Model expectedModel = new ModelManager(SampleEntries.getSampleEntryBook(), new UserPrefs());
         try {
             expectedModel.updateEntry(expectedModel.getFilteredDeadlineList().get(INDEX_FIRST_ENTRY.getZeroBased()),
-                                  editedEntry);
+                                      editedEntry);
         } catch (EntryOverdueException eoe) {
             // Do nothing. Accept overdue entries in test.
         }
@@ -123,7 +118,8 @@ public class EditByFindCommandTest {
         editedEntry.setName(new Name(VALID_NAME_MEETING));
         editedEntry.setTags(entryInFilteredList.getTags());
         EditCommand editCommand = prepareCommand(model, keywords,
-                new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING).build());
+                                                 new EditEntryDescriptorBuilder().withName(VALID_NAME_MEETING)
+                                                                                 .build());
         String expectedMessage = String.format(EditByFindCommand.MESSAGE_SUCCESS, entryInFilteredList, editedEntry);
         Model expectedModel = new ModelManager(new EntryBook(model.getEntryBook()), new UserPrefs());
 
@@ -155,14 +151,14 @@ public class EditByFindCommandTest {
         thrown.expect(CommandException.class);
         thrown.expectMessage(EditByFindCommand.MESSAGE_NO_ENTRIES);
 
-        String searchString = "asdfasdf";
+        String searchString = "a random string";
         HashSet<String> keywords = new HashSet<>(Arrays.asList(searchString.split("\\s+")));
         EditEntryDescriptor editEntryDescriptor = new EditEntryDescriptor();
         EditCommand editCommand = prepareCommand(model, keywords, editEntryDescriptor);
 
         editCommand.execute();
     }
-    // @@author A0140633R
+    // @@author
 
     @Test
     public void equals() {
@@ -214,25 +210,6 @@ public class EditByFindCommandTest {
                                              PowerMatch.Level.LEVEL_0);
 
         assertTrue(model.getFilteredFloatingTaskList().size() == 1);
-    }
-
-    /**
-     * Converts date to a calendar
-     */
-    private Calendar parseDate(String args) throws Exception {
-        PrettyTimeParser ptp = new PrettyTimeParser();
-        Calendar calendar = new GregorianCalendar();
-        try {
-            List<Date> dates = ptp.parse(args);
-            Date date = dates.get(0);
-            calendar.setTime(date);
-            return calendar;
-
-        } catch (Exception e) {
-            // double exception catching as a fail-safe
-            fail("should not give invalid dates to parse");
-            return null;
-        }
     }
 
 }

--- a/src/test/java/seedu/multitasky/logic/commands/EditByIndexCommandTest.java
+++ b/src/test/java/seedu/multitasky/logic/commands/EditByIndexCommandTest.java
@@ -69,7 +69,7 @@ public class EditByIndexCommandTest {
         CommandResult result = editCommand.execute();
         try {
             expectedModel.updateEntry(expectedModel.getFilteredEventList().get(INDEX_FIRST_ENTRY.getZeroBased()),
-                                  editedEntry);
+                                      editedEntry);
         } catch (EntryOverdueException eoe) {
             // Do nothing. Accept overdue entries in test.
         }

--- a/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/AddCommandParserTest.java
@@ -28,6 +28,8 @@ import seedu.multitasky.model.UserPrefs;
 public class AddCommandParserTest {
     private static final String VALID_DATE_17JULY = "17 july 2017";
     private static final String VALID_DATE_20JULY = "20 july 2017";
+    private static final String VALID_DATE_TIME_25JULY6PM = "25 july 6pm";
+    private static final String VALID_TIME_9PM = "9pm";
     private static final String INVALID_DATE = "end of time";
 
     @Rule
@@ -88,6 +90,11 @@ public class AddCommandParserTest {
         command = parser.parse(" a special event with only end date " + PREFIX_TO + " " + VALID_DATE_17JULY, userprefs);
         assertTrue(command instanceof AddCommand);
 
+        // both start and end date given but end date only has time fields
+        command = parser.parse(" an event with end date infered to be same date as start date "
+                               + PREFIX_FROM + " " + VALID_DATE_TIME_25JULY6PM + " " + PREFIX_TO
+                               + " " + VALID_TIME_9PM, userprefs);
+        assertTrue(command instanceof AddCommand);
     }
 
     public void parse_invalidArgsFollowedByValidArgs_returnsAddCommand() throws Exception {

--- a/src/test/java/seedu/multitasky/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/EditCommandParserTest.java
@@ -16,10 +16,13 @@ import static seedu.multitasky.logic.parser.ParserUtil.MESSAGE_FAIL_PARSE_DATE;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_11_JULY_17;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_12_JULY_17;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_20_DEC_17;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_TIME_12_JULY_6PM;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_DATE_TIME_12_JULY_9PM;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_CLEAN;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_NAME_MEETING;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_FRIEND;
 import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TAG_URGENT;
+import static seedu.multitasky.testutil.EditCommandTestUtil.VALID_TIME_9PM;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_FIRST_ENTRY;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_SECOND_ENTRY;
 import static seedu.multitasky.testutil.SampleEntries.INDEX_THIRD_ENTRY;
@@ -52,6 +55,8 @@ public class EditCommandParserTest {
     private static final String NAME_DESC_CLEAN = " " + PREFIX_NAME + " " + VALID_NAME_CLEAN;
     private static final String NAME_DESC_MEETING = " " + PREFIX_NAME + " " + VALID_NAME_MEETING;
     private static final String DATE_DESC_START_12JULY = " " + PREFIX_FROM + " " + VALID_DATE_12_JULY_17;
+    private static final String DATE_TIME_DESC_START_12JULY6PM = " " + PREFIX_FROM + " " + VALID_DATE_TIME_12_JULY_6PM;
+    private static final String TIME_DESC_END_9PM = " " + PREFIX_TO + " " + VALID_TIME_9PM;
     private static final String DATE_DESC_END_12JULY = " " + PREFIX_TO + " " + VALID_DATE_12_JULY_17;
     private static final String DATE_DESC_END_11JULY = " " + PREFIX_BY + " " + VALID_DATE_11_JULY_17;
     private static final String DATE_DESC_END_20DEC = " " + PREFIX_BY + " " + VALID_DATE_20_DEC_17;
@@ -162,7 +167,6 @@ public class EditCommandParserTest {
 
         assertParseSuccess(userInput, expectedCommand);
     }
-    // @@author
 
     @Test
     public void parse_byIndexSomeFieldsSpecified_success() throws Exception {
@@ -179,6 +183,14 @@ public class EditCommandParserTest {
         userInput = PREFIX_DESC_FLOAT + targetIndex.getOneBased() + DATE_DESC_START_12JULY + DATE_DESC_END_12JULY;
         descriptor = new EditEntryDescriptorBuilder().withStartDate(VALID_DATE_12_JULY_17)
                                                      .withEndDate(VALID_DATE_12_JULY_17).build();
+        expectedCommand = new EditByIndexCommand(targetIndex, PREFIX_EVENT, descriptor);
+        assertParseSuccess(userInput, expectedCommand);
+
+        // full start date time given but only end time. parser should infer month, date fields from start date.
+        userInput = PREFIX_DESC_FLOAT + targetIndex.getOneBased() + DATE_TIME_DESC_START_12JULY6PM
+                    + TIME_DESC_END_9PM;
+        descriptor = new EditEntryDescriptorBuilder().withStartDate(VALID_DATE_TIME_12_JULY_6PM)
+                                                     .withEndDate(VALID_DATE_TIME_12_JULY_9PM).build();
         expectedCommand = new EditByIndexCommand(targetIndex, PREFIX_EVENT, descriptor);
         assertParseSuccess(userInput, expectedCommand);
     }

--- a/src/test/java/seedu/multitasky/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/EditCommandParserTest.java
@@ -270,7 +270,7 @@ public class EditCommandParserTest {
         // assumes editEntry has been saved in history
         history.setEditHistory(EditCommandTestUtil.DESC_MEETING);
 
-        String userInput = searchString + NAME_DESC_CLEAN;
+        String userInput = searchString;
         EditEntryDescriptor descriptor = history.getEditHistory();
         EditCommand expectedCommand = new EditByFindCommand(keywordSet, descriptor);
         assertParseSuccess(userInput, expectedCommand);

--- a/src/test/java/seedu/multitasky/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/multitasky/logic/parser/ParserUtilTest.java
@@ -26,7 +26,7 @@ import seedu.multitasky.model.tag.Tag;
 
 // @@author A0140633R
 /**
- * Contains tests for ParserUtil methods used by the parser classes.
+ * Contains unit tests for ParserUtil methods used by the parser classes.
  */
 // @@author
 public class ParserUtilTest {
@@ -36,6 +36,7 @@ public class ParserUtilTest {
     private static final String VALID_TAG_1 = "with_friends";
     private static final String VALID_TAG_2 = "priority";
     private static final String VALID_DATE = "12/1/17 18:30:00";
+    private static final String VALID_DATE_2 = "12/1/17 19:00:00";
     private static final Prefix VALID_PREFIX_TAG = CliSyntax.PREFIX_TAG;
     private static final Prefix VALID_PREFIX_FLOAT = CliSyntax.PREFIX_FLOATINGTASK;
 
@@ -180,6 +181,20 @@ public class ParserUtilTest {
         Date expectedDate = sdf.parse(VALID_DATE);
         expectedCalendar.setTime(expectedDate);
         Optional<Calendar> actualCalendar = ParserUtil.parseDate(Optional.of(VALID_DATE));
+
+        assertTrue(expectedCalendar.compareTo(actualCalendar.get()) == 0);
+    }
+
+    @Test
+    public void parseExtendedDate_validValue_returnsCalendar() throws Exception {
+        Calendar expectedCalendar = new GregorianCalendar();
+        // following MM/dd/yy format of prettyTime dependency.
+        SimpleDateFormat sdf = new SimpleDateFormat("MM/dd/yy HH:mm:ss");
+        sdf.setLenient(false);
+        Date expectedDate = sdf.parse(VALID_DATE_2);
+        expectedCalendar.setTime(expectedDate);
+        Optional<Calendar> actualCalendar = ParserUtil.parseExtendedDate(Optional.of(VALID_DATE),
+                                                                         Optional.of(VALID_DATE_2));
 
         assertTrue(expectedCalendar.compareTo(actualCalendar.get()) == 0);
     }

--- a/src/test/java/seedu/multitasky/testutil/EditCommandTestUtil.java
+++ b/src/test/java/seedu/multitasky/testutil/EditCommandTestUtil.java
@@ -13,6 +13,9 @@ public class EditCommandTestUtil {
     public static final String VALID_TAG_URGENT = "urgent";
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_DATE_12_JULY_17 = "12 july 17";
+    public static final String VALID_DATE_TIME_12_JULY_6PM = "12 july 6pm";
+    public static final String VALID_TIME_9PM = "9pm";
+    public static final String VALID_DATE_TIME_12_JULY_9PM = "12 july 9pm";
     public static final String VALID_DATE_11_JULY_17 = "11 july 17";
     public static final String VALID_DATE_20_DEC_17 = "12 dec 17";
 


### PR DESCRIPTION
Changelog 📜 
- can now give time only for `to` flag when used with a start date flag. it will infer the month date from the start date. e.g. `add study hard from friday 6am to 9pm`
- same for editing tasks
- fix full day events bug
- added some unit tests

ah forgot to mention that the old method of inputting dates works in this way as well, e.g `add study hard from friday 6am to friday 9pm`